### PR TITLE
Render MJML from the AST

### DIFF
--- a/cmd/gomjml/command/compile.go
+++ b/cmd/gomjml/command/compile.go
@@ -36,12 +36,12 @@ Examples:
 				os.Exit(1)
 			}
 
-			// Render MJML to HTML using library
+			// RenderHTML MJML to HTML using library
 			var html string
 			if debug {
-				html, err = mjml.Render(string(mjmlContent), mjml.WithDebugTags(true))
+				html, err = mjml.RenderHTML(string(mjmlContent), mjml.WithDebugTags(true))
 			} else {
-				html, err = mjml.Render(string(mjmlContent))
+				html, err = mjml.RenderHTML(string(mjmlContent))
 			}
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error rendering MJML: %v\n", err)

--- a/examples/basic/basic.go
+++ b/examples/basic/basic.go
@@ -24,9 +24,9 @@ func main() {
       </mjml>`
 
 	// Method 1: Direct rendering (recommended)
-	html, err := mjml.Render(mjmlContent)
+	html, err := mjml.RenderHTML(mjmlContent)
 	if err != nil {
-		log.Fatal("Render error:", err)
+		log.Fatal("RenderHTML error:", err)
 	}
 	fmt.Println(html)
 
@@ -43,7 +43,7 @@ func main() {
 
 	html, err = mjml.RenderComponentString(component)
 	if err != nil {
-		log.Fatal("Render error:", err)
+		log.Fatal("RenderHTML error:", err)
 	}
 	fmt.Println(html)
 }

--- a/examples/sendmail/sendmail.go
+++ b/examples/sendmail/sendmail.go
@@ -35,8 +35,8 @@ func main() {
 		log.Fatalf("Failed to read MJML file: %v", err)
 	}
 
-	// Render MJML to HTML
-	html, err := mjml.Render(string(mjmlContent))
+	// RenderHTML MJML to HTML
+	html, err := mjml.RenderHTML(string(mjmlContent))
 	if err != nil {
 		log.Fatalf("MJML render error: %v", err)
 	}

--- a/mjml/benchmark_test.go
+++ b/mjml/benchmark_test.go
@@ -76,9 +76,9 @@ func BenchmarkMJMLRender_10_Sections(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := Render(template)
+		_, err := RenderHTML(template)
 		if err != nil {
-			b.Fatalf("Render failed: %v", err)
+			b.Fatalf("RenderHTML failed: %v", err)
 		}
 	}
 }
@@ -89,9 +89,9 @@ func BenchmarkMJMLRender_100_Sections(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := Render(template)
+		_, err := RenderHTML(template)
 		if err != nil {
-			b.Fatalf("Render failed: %v", err)
+			b.Fatalf("RenderHTML failed: %v", err)
 		}
 	}
 }
@@ -102,9 +102,9 @@ func BenchmarkMJMLRender_1000_Sections(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := Render(template)
+		_, err := RenderHTML(template)
 		if err != nil {
-			b.Fatalf("Render failed: %v", err)
+			b.Fatalf("RenderHTML failed: %v", err)
 		}
 	}
 }
@@ -116,9 +116,9 @@ func BenchmarkMJMLRender_10_Sections_Memory(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := Render(template)
+		_, err := RenderHTML(template)
 		if err != nil {
-			b.Fatalf("Render failed: %v", err)
+			b.Fatalf("RenderHTML failed: %v", err)
 		}
 	}
 }
@@ -130,9 +130,9 @@ func BenchmarkMJMLRender_100_Sections_Memory(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := Render(template)
+		_, err := RenderHTML(template)
 		if err != nil {
-			b.Fatalf("Render failed: %v", err)
+			b.Fatalf("RenderHTML failed: %v", err)
 		}
 	}
 }
@@ -144,9 +144,9 @@ func BenchmarkMJMLRender_1000_Sections_Memory(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := Render(template)
+		_, err := RenderHTML(template)
 		if err != nil {
-			b.Fatalf("Render failed: %v", err)
+			b.Fatalf("RenderHTML failed: %v", err)
 		}
 	}
 }
@@ -207,9 +207,9 @@ func BenchmarkMJMLRender_100_Sections_Writer(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		var buf strings.Builder
-		err := component.Render(&buf)
+		err := component.RenderHTML(&buf)
 		if err != nil {
-			b.Fatalf("Render failed: %v", err)
+			b.Fatalf("RenderHTML failed: %v", err)
 		}
 		_ = buf.String() // Force evaluation to match string-based benchmark
 	}
@@ -222,9 +222,9 @@ func BenchmarkMJMLRender_vs_RenderString_100_Sections(b *testing.B) {
 	b.Run("String-based", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			_, err := Render(template)
+			_, err := RenderHTML(template)
 			if err != nil {
-				b.Fatalf("Render failed: %v", err)
+				b.Fatalf("RenderHTML failed: %v", err)
 			}
 		}
 	})
@@ -242,9 +242,9 @@ func BenchmarkMJMLRender_vs_RenderString_100_Sections(b *testing.B) {
 			}
 
 			var buf strings.Builder
-			err = component.Render(&buf)
+			err = component.RenderHTML(&buf)
 			if err != nil {
-				b.Fatalf("Render failed: %v", err)
+				b.Fatalf("RenderHTML failed: %v", err)
 			}
 		}
 	})

--- a/mjml/component.go
+++ b/mjml/component.go
@@ -231,12 +231,24 @@ func processSectionChildren(section *components.MJSectionComponent, opts *option
 }
 
 // RenderComponentString renders the given Component to a string.
-// It creates a strings.Builder writer and passes it to the Component's Render method.
+// It creates a strings.Builder writer and passes it to the Component's RenderHTML method.
 // This function returns the rendered output as a string, or an error if rendering fails.
-// Where possible, it is recommended to use the component's Render function directly for better performance and flexibility.
+// Where possible, it is recommended to use the component's RenderHTML function directly for better performance and flexibility.
 func RenderComponentString(c Component) (string, error) {
 	var output strings.Builder
-	if err := c.Render(&output); err != nil {
+	if err := c.RenderHTML(&output); err != nil {
+		return "", err
+	}
+	return output.String(), nil
+}
+
+// RenderComponentMJMLString renders the given Component to an MJML string.
+// It creates a strings.Builder writer and passes it to the Component's RenderMJML method.
+// This function returns the rendered MJML output as a string, or an error if rendering fails.
+// Where possible, it is recommended to use the component's RenderMJML function directly for better performance and flexibility.
+func RenderComponentMJMLString(c Component) (string, error) {
+	var output strings.Builder
+	if err := c.RenderMJML(&output); err != nil {
 		return "", err
 	}
 	return output.String(), nil

--- a/mjml/components/accordion.go
+++ b/mjml/components/accordion.go
@@ -22,7 +22,7 @@ func NewMJAccordionComponent(node *parser.MJMLNode, opts *options.RenderOpts) *M
 	}
 }
 
-func (c *MJAccordionComponent) Render(w io.StringWriter) error {
+func (c *MJAccordionComponent) RenderHTML(w io.StringWriter) error {
 	border := c.GetAttributeWithDefault(c, constants.MJMLBorder)
 	fontFamily := c.GetAttributeWithDefault(c, constants.MJMLFontFamily)
 	padding := c.GetAttributeWithDefault(c, constants.MJMLPadding)
@@ -87,12 +87,12 @@ func (c *MJAccordionComponent) Render(w io.StringWriter) error {
 		return err
 	}
 
-	// Render accordion elements
+	// RenderHTML accordion elements
 	for _, child := range c.Children {
 		if accordionElement, ok := child.(*MJAccordionElementComponent); ok {
 			accordionElement.SetContainerWidth(c.GetContainerWidth())
 			accordionElement.inheritFromParent(c)
-			if err := accordionElement.Render(w); err != nil {
+			if err := accordionElement.RenderHTML(w); err != nil {
 				return err
 			}
 		}
@@ -108,6 +108,10 @@ func (c *MJAccordionComponent) Render(w io.StringWriter) error {
 
 func (c *MJAccordionComponent) GetTagName() string {
 	return "mj-accordion"
+}
+
+func (c *MJAccordionComponent) RenderMJML(w io.StringWriter) error {
+	return &NotImplementedError{ComponentName: "mj-accordion"}
 }
 
 func (c *MJAccordionComponent) GetDefaultAttribute(name string) string {
@@ -150,8 +154,8 @@ func NewMJAccordionTextComponent(node *parser.MJMLNode, opts *options.RenderOpts
 	}
 }
 
-func (c *MJAccordionTextComponent) Render(w io.StringWriter) error {
-	// Render the raw content inside the accordion text
+func (c *MJAccordionTextComponent) RenderHTML(w io.StringWriter) error {
+	// RenderHTML the raw content inside the accordion text
 	content := strings.TrimSpace(c.Node.Text)
 	if content != "" {
 		if _, err := w.WriteString(content); err != nil {
@@ -177,14 +181,14 @@ func (c *MJAccordionTextComponent) renderHTMLChild(w io.StringWriter, node *pars
 			return err
 		}
 
-		// Render text content
+		// RenderHTML text content
 		if content := strings.TrimSpace(node.Text); content != "" {
 			if _, err := w.WriteString(content); err != nil {
 				return err
 			}
 		}
 
-		// Render children recursively
+		// RenderHTML children recursively
 		for _, child := range node.Children {
 			if err := c.renderHTMLChild(w, child); err != nil {
 				return err
@@ -203,6 +207,10 @@ func (c *MJAccordionTextComponent) renderHTMLChild(w io.StringWriter, node *pars
 		}
 	}
 	return nil
+}
+
+func (c *MJAccordionTextComponent) RenderMJML(w io.StringWriter) error {
+	return &NotImplementedError{ComponentName: "mj-accordion-text"}
 }
 
 func (c *MJAccordionTextComponent) GetTagName() string {
@@ -235,8 +243,8 @@ func NewMJAccordionTitleComponent(node *parser.MJMLNode, opts *options.RenderOpt
 	}
 }
 
-func (c *MJAccordionTitleComponent) Render(w io.StringWriter) error {
-	// Render the raw content inside the accordion title
+func (c *MJAccordionTitleComponent) RenderHTML(w io.StringWriter) error {
+	// RenderHTML the raw content inside the accordion title
 	content := strings.TrimSpace(c.Node.Text)
 	if content != "" {
 		if _, err := w.WriteString(content); err != nil {
@@ -244,6 +252,10 @@ func (c *MJAccordionTitleComponent) Render(w io.StringWriter) error {
 		}
 	}
 	return nil
+}
+
+func (c *MJAccordionTitleComponent) RenderMJML(w io.StringWriter) error {
+	return &NotImplementedError{ComponentName: "mj-accordion-title"}
 }
 
 func (c *MJAccordionTitleComponent) GetTagName() string {
@@ -275,7 +287,7 @@ func NewMJAccordionElementComponent(node *parser.MJMLNode, opts *options.RenderO
 	}
 }
 
-func (c *MJAccordionElementComponent) Render(w io.StringWriter) error {
+func (c *MJAccordionElementComponent) RenderHTML(w io.StringWriter) error {
 	fontSize := c.getAttribute("font-size")
 	fontFamily := c.getAttribute("font-family")
 	backgroundColor := c.getAttribute("background-color")
@@ -351,14 +363,14 @@ func (c *MJAccordionElementComponent) Render(w io.StringWriter) error {
 		}
 	}
 
-	// Render title section
+	// RenderHTML title section
 	if titleComponent != nil {
 		if err := c.renderTitle(w, titleComponent, iconAlign, iconHeight, iconWidth, iconWrappedUrl, iconUnwrappedUrl, iconWrappedAlt, iconUnwrappedAlt); err != nil {
 			return err
 		}
 	}
 
-	// Render content section
+	// RenderHTML content section
 	if textComponent != nil {
 		if err := c.renderContent(w, textComponent); err != nil {
 			return err
@@ -415,7 +427,7 @@ func (c *MJAccordionElementComponent) renderTitle(w io.StringWriter, titleCompon
 		return err
 	}
 
-	// Render icon on left if icon-position="left"
+	// RenderHTML icon on left if icon-position="left"
 	if iconPosition == constants.AlignLeft {
 		if err := c.renderIconCell(w, iconAlign, iconHeight, iconWidth, iconWrappedUrl, iconUnwrappedUrl, iconWrappedAlt, iconUnwrappedAlt, titleComponent, backgroundColor); err != nil {
 			return err
@@ -469,8 +481,8 @@ func (c *MJAccordionElementComponent) renderTitle(w io.StringWriter, titleCompon
 		return err
 	}
 
-	// Render title content
-	if err := titleComponent.Render(w); err != nil {
+	// RenderHTML title content
+	if err := titleComponent.RenderHTML(w); err != nil {
 		return err
 	}
 
@@ -479,7 +491,7 @@ func (c *MJAccordionElementComponent) renderTitle(w io.StringWriter, titleCompon
 		return err
 	}
 
-	// Render icon on right if icon-position="right" (default)
+	// RenderHTML icon on right if icon-position="right" (default)
 	if iconPosition != constants.AlignLeft {
 		if err := c.renderIconCell(w, iconAlign, iconHeight, iconWidth, iconWrappedUrl, iconUnwrappedUrl, iconWrappedAlt, iconUnwrappedAlt, titleComponent, backgroundColor); err != nil {
 			return err
@@ -641,8 +653,8 @@ func (c *MJAccordionElementComponent) renderContent(w io.StringWriter, textCompo
 		return err
 	}
 
-	// Render text content
-	if err := textComponent.Render(w); err != nil {
+	// RenderHTML text content
+	if err := textComponent.RenderHTML(w); err != nil {
 		return err
 	}
 
@@ -652,6 +664,10 @@ func (c *MJAccordionElementComponent) renderContent(w io.StringWriter, textCompo
 	}
 
 	return nil
+}
+
+func (c *MJAccordionElementComponent) RenderMJML(w io.StringWriter) error {
+	return &NotImplementedError{ComponentName: "mj-accordion-element"}
 }
 
 func (c *MJAccordionElementComponent) GetTagName() string {

--- a/mjml/components/base.go
+++ b/mjml/components/base.go
@@ -37,7 +37,8 @@ func (e *NotImplementedError) Error() string {
 
 // Component represents a renderable MJML component
 type Component interface {
-	Render(w io.StringWriter) error
+	RenderHTML(w io.StringWriter) error
+	RenderMJML(w io.StringWriter) error
 	GetTagName() string
 	GetDefaultAttribute(name string) string
 	SetContainerWidth(widthPx int)

--- a/mjml/components/body.go
+++ b/mjml/components/body.go
@@ -34,7 +34,7 @@ func (c *MJBodyComponent) GetTagName() string {
 }
 
 // Render implements optimized Writer-based rendering for MJBodyComponent
-func (c *MJBodyComponent) Render(w io.StringWriter) error {
+func (c *MJBodyComponent) RenderHTML(w io.StringWriter) error {
 	// Apply background-color to div if specified (matching MRML's set_body_style)
 	backgroundColor := c.GetAttribute("background-color")
 
@@ -49,7 +49,7 @@ func (c *MJBodyComponent) Render(w io.StringWriter) error {
 	}
 
 	for _, child := range c.Children {
-		if err := child.Render(w); err != nil {
+		if err := child.RenderHTML(w); err != nil {
 			return err
 		}
 	}
@@ -59,6 +59,10 @@ func (c *MJBodyComponent) Render(w io.StringWriter) error {
 	}
 
 	return nil
+}
+
+func (c *MJBodyComponent) RenderMJML(w io.StringWriter) error {
+	return &NotImplementedError{ComponentName: "mj-body"}
 }
 
 func (c *MJBodyComponent) GetDefaultAttribute(name string) string {

--- a/mjml/components/body.go
+++ b/mjml/components/body.go
@@ -62,7 +62,33 @@ func (c *MJBodyComponent) RenderHTML(w io.StringWriter) error {
 }
 
 func (c *MJBodyComponent) RenderMJML(w io.StringWriter) error {
-	return &NotImplementedError{ComponentName: "mj-body"}
+	if _, err := w.WriteString("\n  <mj-body"); err != nil {
+		return err
+	}
+
+	// Render attributes
+	for name, value := range c.Attrs {
+		if _, err := w.WriteString(" " + name + "=\"" + value + "\""); err != nil {
+			return err
+		}
+	}
+
+	if _, err := w.WriteString(">"); err != nil {
+		return err
+	}
+
+	// Render children
+	for _, child := range c.Children {
+		if err := child.RenderMJML(w); err != nil {
+			return err
+		}
+	}
+
+	if _, err := w.WriteString("\n  </mj-body>"); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (c *MJBodyComponent) GetDefaultAttribute(name string) string {

--- a/mjml/components/button.go
+++ b/mjml/components/button.go
@@ -69,7 +69,7 @@ func (c *MJButtonComponent) GetTagName() string {
 }
 
 // Render implements optimized Writer-based rendering for MJButtonComponent
-func (c *MJButtonComponent) Render(w io.StringWriter) error {
+func (c *MJButtonComponent) RenderHTML(w io.StringWriter) error {
 	// Get text content
 	textContent := c.Node.Text
 	if textContent == "" {
@@ -232,6 +232,10 @@ func (c *MJButtonComponent) Render(w io.StringWriter) error {
 	}
 
 	return nil
+}
+
+func (c *MJButtonComponent) RenderMJML(w io.StringWriter) error {
+	return &NotImplementedError{ComponentName: "mj-button"}
 }
 
 func (c *MJButtonComponent) GetDefaultAttribute(name string) string {

--- a/mjml/components/carousel.go
+++ b/mjml/components/carousel.go
@@ -18,8 +18,12 @@ func NewMJCarouselComponent(node *parser.MJMLNode, opts *options.RenderOpts) *MJ
 	}
 }
 
-func (c *MJCarouselComponent) Render(w io.StringWriter) error {
+func (c *MJCarouselComponent) RenderHTML(w io.StringWriter) error {
 	// TODO: Implement mj-carousel component functionality
+	return &NotImplementedError{ComponentName: "mj-carousel"}
+}
+
+func (c *MJCarouselComponent) RenderMJML(w io.StringWriter) error {
 	return &NotImplementedError{ComponentName: "mj-carousel"}
 }
 
@@ -69,8 +73,12 @@ func NewMJCarouselImageComponent(node *parser.MJMLNode, opts *options.RenderOpts
 	}
 }
 
-func (c *MJCarouselImageComponent) Render(w io.StringWriter) error {
+func (c *MJCarouselImageComponent) RenderHTML(w io.StringWriter) error {
 	// TODO: Implement mj-carousel-image component functionality
+	return &NotImplementedError{ComponentName: "mj-carousel-image"}
+}
+
+func (c *MJCarouselImageComponent) RenderMJML(w io.StringWriter) error {
 	return &NotImplementedError{ComponentName: "mj-carousel-image"}
 }
 

--- a/mjml/components/column.go
+++ b/mjml/components/column.go
@@ -139,7 +139,33 @@ func (c *MJColumnComponent) renderColumnWithStylesToWriter(w io.StringWriter, in
 }
 
 func (c *MJColumnComponent) RenderMJML(w io.StringWriter) error {
-	return &NotImplementedError{ComponentName: "mj-column"}
+	if _, err := w.WriteString("\n      <mj-column"); err != nil {
+		return err
+	}
+
+	// Render attributes
+	for name, value := range c.Attrs {
+		if _, err := w.WriteString(" " + name + "=\"" + value + "\""); err != nil {
+			return err
+		}
+	}
+
+	if _, err := w.WriteString(">"); err != nil {
+		return err
+	}
+
+	// Render children
+	for _, child := range c.Children {
+		if err := child.RenderMJML(w); err != nil {
+			return err
+		}
+	}
+
+	if _, err := w.WriteString("\n      </mj-column>"); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (c *MJColumnComponent) GetDefaultAttribute(name string) string {

--- a/mjml/components/column.go
+++ b/mjml/components/column.go
@@ -34,7 +34,7 @@ func (c *MJColumnComponent) GetTagName() string {
 }
 
 // Render implements optimized Writer-based rendering for MJColumnComponent
-func (c *MJColumnComponent) Render(w io.StringWriter) error {
+func (c *MJColumnComponent) RenderHTML(w io.StringWriter) error {
 	// Helper function to get attribute with default
 	getAttr := func(name string) string {
 		if attr := c.GetAttribute(name); attr != nil {
@@ -121,9 +121,9 @@ func (c *MJColumnComponent) renderColumnWithStylesToWriter(w io.StringWriter, in
 		return err
 	}
 
-	// Render column content (child components)
+	// RenderHTML column content (child components)
 	for _, child := range c.Children {
-		if err := child.Render(w); err != nil {
+		if err := child.RenderHTML(w); err != nil {
 			return err
 		}
 	}
@@ -136,6 +136,10 @@ func (c *MJColumnComponent) renderColumnWithStylesToWriter(w io.StringWriter, in
 	}
 
 	return nil
+}
+
+func (c *MJColumnComponent) RenderMJML(w io.StringWriter) error {
+	return &NotImplementedError{ComponentName: "mj-column"}
 }
 
 func (c *MJColumnComponent) GetDefaultAttribute(name string) string {

--- a/mjml/components/divider.go
+++ b/mjml/components/divider.go
@@ -20,6 +20,10 @@ func NewMJDividerComponent(node *parser.MJMLNode, opts *options.RenderOpts) *MJD
 	}
 }
 
+func (c *MJDividerComponent) RenderMJML(w io.StringWriter) error {
+	return &NotImplementedError{ComponentName: "mj-divider"}
+}
+
 func (c *MJDividerComponent) GetDefaultAttribute(name string) string {
 	switch name {
 	case "align":
@@ -46,7 +50,7 @@ func (c *MJDividerComponent) getAttribute(name string) string {
 }
 
 // Render implements optimized Writer-based rendering for MJDividerComponent
-func (c *MJDividerComponent) Render(w io.StringWriter) error {
+func (c *MJDividerComponent) RenderHTML(w io.StringWriter) error {
 	padding := c.getAttribute("padding")
 	borderColor := c.getAttribute("border-color")
 	borderStyle := c.getAttribute("border-style")
@@ -92,7 +96,7 @@ func (c *MJDividerComponent) Render(w io.StringWriter) error {
 	width := c.getAttribute("width")
 	p = p.AddStyle("width", width)
 
-	// Render paragraph - must be empty, not self-closing to match MRML
+	// RenderHTML paragraph - must be empty, not self-closing to match MRML
 	if err := p.RenderOpen(w); err != nil {
 		return err
 	}

--- a/mjml/components/group.go
+++ b/mjml/components/group.go
@@ -42,6 +42,10 @@ func NewMJGroupComponent(node *parser.MJMLNode, opts *options.RenderOpts) *MJGro
 	}
 }
 
+func (c *MJGroupComponent) RenderMJML(w io.StringWriter) error {
+	return &NotImplementedError{ComponentName: "mj-group"}
+}
+
 func (c *MJGroupComponent) GetDefaultAttribute(name string) string {
 	switch name {
 	case "direction":
@@ -64,7 +68,7 @@ func (c *MJGroupComponent) GetTagName() string {
 }
 
 // Render implements optimized Writer-based rendering for MJGroupComponent
-func (c *MJGroupComponent) Render(w io.StringWriter) error {
+func (c *MJGroupComponent) RenderHTML(w io.StringWriter) error {
 	direction := c.getAttribute("direction")
 	verticalAlign := c.getAttribute("vertical-align")
 	backgroundColor := c.getAttribute("background-color")
@@ -131,7 +135,7 @@ func (c *MJGroupComponent) Render(w io.StringWriter) error {
 		return err
 	}
 
-	// Render each column in the group
+	// RenderHTML each column in the group
 	for _, child := range c.Children {
 		if columnComp, ok := child.(*MJColumnComponent); ok {
 			// Set the column width based on group's width distribution
@@ -168,8 +172,8 @@ func (c *MJGroupComponent) Render(w io.StringWriter) error {
 			childOpts.InsideGroup = true
 			columnComp.RenderOpts = &childOpts
 
-			// Render column content with padding support table wrapper
-			if err := child.Render(w); err != nil {
+			// RenderHTML column content with padding support table wrapper
+			if err := child.RenderHTML(w); err != nil {
 				return err
 			}
 

--- a/mjml/components/head.go
+++ b/mjml/components/head.go
@@ -20,12 +20,16 @@ func NewMJHeadComponent(node *parser.MJMLNode, opts *options.RenderOpts) *MJHead
 	}
 }
 
-func (c *MJHeadComponent) Render(w io.StringWriter) error {
+func (c *MJHeadComponent) RenderHTML(w io.StringWriter) error {
 	return nil // Head is handled in MJML component
 }
 
 func (c *MJHeadComponent) GetTagName() string {
 	return "mj-head"
+}
+
+func (c *MJHeadComponent) RenderMJML(w io.StringWriter) error {
+	return &NotImplementedError{ComponentName: "mj-head"}
 }
 
 func (c *MJHeadComponent) GetDefaultAttribute(name string) string {
@@ -44,8 +48,12 @@ func NewMJTitleComponent(node *parser.MJMLNode, opts *options.RenderOpts) *MJTit
 	}
 }
 
-func (c *MJTitleComponent) Render(w io.StringWriter) error {
+func (c *MJTitleComponent) RenderHTML(w io.StringWriter) error {
 	return nil // Title is handled in MJML component head processing
+}
+
+func (c *MJTitleComponent) RenderMJML(w io.StringWriter) error {
+	return &NotImplementedError{ComponentName: "mj-title"}
 }
 
 func (c *MJTitleComponent) GetTagName() string {
@@ -68,8 +76,12 @@ func NewMJFontComponent(node *parser.MJMLNode, opts *options.RenderOpts) *MJFont
 	}
 }
 
-func (c *MJFontComponent) Render(w io.StringWriter) error {
+func (c *MJFontComponent) RenderHTML(w io.StringWriter) error {
 	return nil // Font is handled in MJML component head processing
+}
+
+func (c *MJFontComponent) RenderMJML(w io.StringWriter) error {
+	return &NotImplementedError{ComponentName: "mj-font"}
 }
 
 func (c *MJFontComponent) GetTagName() string {
@@ -99,7 +111,7 @@ func NewMJPreviewComponent(node *parser.MJMLNode, opts *options.RenderOpts) *MJP
 	}
 }
 
-func (c *MJPreviewComponent) Render(w io.StringWriter) error {
+func (c *MJPreviewComponent) RenderHTML(w io.StringWriter) error {
 	// Preview text is rendered as hidden div in body
 	if c.Node.Text != "" {
 		previewHTML := fmt.Sprintf(
@@ -110,6 +122,10 @@ func (c *MJPreviewComponent) Render(w io.StringWriter) error {
 		return err
 	}
 	return nil
+}
+
+func (c *MJPreviewComponent) RenderMJML(w io.StringWriter) error {
+	return &NotImplementedError{ComponentName: "mj-preview"}
 }
 
 func (c *MJPreviewComponent) GetTagName() string {
@@ -132,7 +148,7 @@ func NewMJStyleComponent(node *parser.MJMLNode, opts *options.RenderOpts) *MJSty
 	}
 }
 
-func (c *MJStyleComponent) Render(w io.StringWriter) error {
+func (c *MJStyleComponent) RenderHTML(w io.StringWriter) error {
 	// Custom CSS styles - render as style tag
 	if c.Node.Text != "" {
 		styleHTML := fmt.Sprintf(`<style type="text/css">%s</style>`, c.Node.Text)
@@ -140,6 +156,10 @@ func (c *MJStyleComponent) Render(w io.StringWriter) error {
 		return err
 	}
 	return nil
+}
+
+func (c *MJStyleComponent) RenderMJML(w io.StringWriter) error {
+	return &NotImplementedError{ComponentName: "mj-style"}
 }
 
 func (c *MJStyleComponent) GetTagName() string {
@@ -162,8 +182,12 @@ func NewMJAttributesComponent(node *parser.MJMLNode, opts *options.RenderOpts) *
 	}
 }
 
-func (c *MJAttributesComponent) Render(w io.StringWriter) error {
+func (c *MJAttributesComponent) RenderHTML(w io.StringWriter) error {
 	return nil // Attributes are processed during parsing, no HTML output
+}
+
+func (c *MJAttributesComponent) RenderMJML(w io.StringWriter) error {
+	return &NotImplementedError{ComponentName: "mj-attributes"}
 }
 
 func (c *MJAttributesComponent) GetTagName() string {
@@ -186,8 +210,12 @@ func NewMJAllComponent(node *parser.MJMLNode, opts *options.RenderOpts) *MJAllCo
 	}
 }
 
-func (c *MJAllComponent) Render(w io.StringWriter) error {
+func (c *MJAllComponent) RenderHTML(w io.StringWriter) error {
 	return nil // Global attributes are processed during parsing, no HTML output
+}
+
+func (c *MJAllComponent) RenderMJML(w io.StringWriter) error {
+	return &NotImplementedError{ComponentName: "mj-all"}
 }
 
 func (c *MJAllComponent) GetTagName() string {

--- a/mjml/components/hero.go
+++ b/mjml/components/hero.go
@@ -18,13 +18,17 @@ func NewMJHeroComponent(node *parser.MJMLNode, opts *options.RenderOpts) *MJHero
 	}
 }
 
-func (c *MJHeroComponent) Render(w io.StringWriter) error {
+func (c *MJHeroComponent) RenderHTML(w io.StringWriter) error {
 	// TODO: Implement mj-hero component functionality
 	return &NotImplementedError{ComponentName: "mj-hero"}
 }
 
 func (c *MJHeroComponent) GetTagName() string {
 	return "mj-hero"
+}
+
+func (c *MJHeroComponent) RenderMJML(w io.StringWriter) error {
+	return &NotImplementedError{ComponentName: "mj-hero"}
 }
 
 func (c *MJHeroComponent) GetDefaultAttribute(name string) string {

--- a/mjml/components/image.go
+++ b/mjml/components/image.go
@@ -28,7 +28,7 @@ func (c *MJImageComponent) GetTagName() string {
 }
 
 // Render implements optimized Writer-based rendering for MJImageComponent
-func (c *MJImageComponent) Render(w io.StringWriter) error {
+func (c *MJImageComponent) RenderHTML(w io.StringWriter) error {
 	// Helper function to get attribute with default
 	getAttr := func(name string) string {
 		if attr := c.GetAttribute(name); attr != nil {
@@ -196,6 +196,10 @@ func (c *MJImageComponent) Render(w io.StringWriter) error {
 	}
 
 	return nil
+}
+
+func (c *MJImageComponent) RenderMJML(w io.StringWriter) error {
+	return &NotImplementedError{ComponentName: "mj-image"}
 }
 
 func (c *MJImageComponent) GetDefaultAttribute(name string) string {

--- a/mjml/components/navbar.go
+++ b/mjml/components/navbar.go
@@ -19,8 +19,12 @@ func NewMJNavbarComponent(node *parser.MJMLNode, opts *options.RenderOpts) *MJNa
 	}
 }
 
-func (c *MJNavbarComponent) Render(w io.StringWriter) error {
+func (c *MJNavbarComponent) RenderHTML(w io.StringWriter) error {
 	// TODO: Implement mj-navbar component functionality
+	return &NotImplementedError{ComponentName: "mj-navbar"}
+}
+
+func (c *MJNavbarComponent) RenderMJML(w io.StringWriter) error {
 	return &NotImplementedError{ComponentName: "mj-navbar"}
 }
 
@@ -68,8 +72,12 @@ func NewMJNavbarLinkComponent(node *parser.MJMLNode, opts *options.RenderOpts) *
 	}
 }
 
-func (c *MJNavbarLinkComponent) Render(w io.StringWriter) error {
+func (c *MJNavbarLinkComponent) RenderHTML(w io.StringWriter) error {
 	// TODO: Implement mj-navbar-link component functionality
+	return &NotImplementedError{ComponentName: "mj-navbar-link"}
+}
+
+func (c *MJNavbarLinkComponent) RenderMJML(w io.StringWriter) error {
 	return &NotImplementedError{ComponentName: "mj-navbar-link"}
 }
 

--- a/mjml/components/raw.go
+++ b/mjml/components/raw.go
@@ -31,7 +31,7 @@ func (c *MJRawComponent) GetDefaultAttribute(name string) string {
 }
 
 // Render implements optimized Writer-based rendering for MJRawComponent
-func (c *MJRawComponent) Render(w io.StringWriter) error {
+func (c *MJRawComponent) RenderHTML(w io.StringWriter) error {
 	// mj-raw simply outputs its content as-is, without any wrapping HTML
 	// The content includes both text and child nodes as raw HTML
 	content := c.getRawContent()
@@ -104,4 +104,8 @@ func (c *MJRawComponent) nodeToHTML(node *parser.MJMLNode) string {
 
 	html += "</" + tagName + ">"
 	return html
+}
+
+func (c *MJRawComponent) RenderMJML(w io.StringWriter) error {
+	return &NotImplementedError{ComponentName: "mj-raw"}
 }

--- a/mjml/components/section.go
+++ b/mjml/components/section.go
@@ -27,7 +27,7 @@ func (c *MJSectionComponent) GetTagName() string {
 }
 
 // Render implements optimized Writer-based rendering for MJSectionComponent
-func (c *MJSectionComponent) Render(w io.StringWriter) error {
+func (c *MJSectionComponent) RenderHTML(w io.StringWriter) error {
 	// Helper function to get attribute with default
 	getAttr := func(name string) string {
 		if attr := c.GetAttribute(name); attr != nil {
@@ -166,7 +166,7 @@ func (c *MJSectionComponent) Render(w io.StringWriter) error {
 		}
 	}
 
-	// Render child columns and groups (section provides MSO TR, columns provide MSO TDs)
+	// RenderHTML child columns and groups (section provides MSO TR, columns provide MSO TDs)
 	for _, child := range c.Children {
 		// Pass the effective width and sibling counts to the child
 		child.SetContainerWidth(c.GetEffectiveWidth())
@@ -221,7 +221,7 @@ func (c *MJSectionComponent) Render(w io.StringWriter) error {
 		}
 
 		// Use optimized rendering with fallback to string-based
-		if err := child.Render(w); err != nil {
+		if err := child.RenderHTML(w); err != nil {
 			return err
 		}
 
@@ -263,6 +263,10 @@ func (c *MJSectionComponent) Render(w io.StringWriter) error {
 	}
 
 	return nil
+}
+
+func (c *MJSectionComponent) RenderMJML(w io.StringWriter) error {
+	return &NotImplementedError{ComponentName: "mj-section"}
 }
 
 func (c *MJSectionComponent) GetDefaultAttribute(name string) string {

--- a/mjml/components/section.go
+++ b/mjml/components/section.go
@@ -266,7 +266,33 @@ func (c *MJSectionComponent) RenderHTML(w io.StringWriter) error {
 }
 
 func (c *MJSectionComponent) RenderMJML(w io.StringWriter) error {
-	return &NotImplementedError{ComponentName: "mj-section"}
+	if _, err := w.WriteString("\n    <mj-section"); err != nil {
+		return err
+	}
+
+	// Render attributes
+	for name, value := range c.Attrs {
+		if _, err := w.WriteString(" " + name + "=\"" + value + "\""); err != nil {
+			return err
+		}
+	}
+
+	if _, err := w.WriteString(">"); err != nil {
+		return err
+	}
+
+	// Render children
+	for _, child := range c.Children {
+		if err := child.RenderMJML(w); err != nil {
+			return err
+		}
+	}
+
+	if _, err := w.WriteString("\n    </mj-section>"); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (c *MJSectionComponent) GetDefaultAttribute(name string) string {

--- a/mjml/components/social.go
+++ b/mjml/components/social.go
@@ -91,7 +91,7 @@ func (c *MJSocialComponent) getAttribute(name string) string {
 }
 
 // Render implements optimized Writer-based rendering for MJSocialComponent
-func (c *MJSocialComponent) Render(w io.StringWriter) error {
+func (c *MJSocialComponent) RenderHTML(w io.StringWriter) error {
 	padding := c.getAttribute(constants.MJMLPadding)
 	align := c.getAttribute(constants.MJMLAlign)
 	mode := c.getAttribute(constants.MJMLMode)
@@ -150,13 +150,13 @@ func (c *MJSocialComponent) Render(w io.StringWriter) error {
 			return err
 		}
 
-		// Render social elements as table rows
+		// RenderHTML social elements as table rows
 		for _, child := range c.Children {
 			if socialElement, ok := child.(*MJSocialElementComponent); ok {
 				socialElement.SetContainerWidth(c.GetContainerWidth())
 				socialElement.InheritFromParent(c)
 				socialElement.SetVerticalMode(true)
-				if err := socialElement.Render(w); err != nil {
+				if err := socialElement.RenderHTML(w); err != nil {
 					return err
 				}
 			}
@@ -182,12 +182,12 @@ func (c *MJSocialComponent) Render(w io.StringWriter) error {
 			return err
 		}
 
-		// Render social elements
+		// RenderHTML social elements
 		for _, child := range c.Children {
 			if socialElement, ok := child.(*MJSocialElementComponent); ok {
 				socialElement.SetContainerWidth(c.GetContainerWidth())
 				socialElement.InheritFromParent(c)
-				if err := socialElement.Render(w); err != nil {
+				if err := socialElement.RenderHTML(w); err != nil {
 					return err
 				}
 			}
@@ -209,6 +209,10 @@ func (c *MJSocialComponent) Render(w io.StringWriter) error {
 	}
 
 	return nil
+}
+
+func (c *MJSocialComponent) RenderMJML(w io.StringWriter) error {
+	return &NotImplementedError{ComponentName: "mj-social"}
 }
 
 func (c *MJSocialComponent) GetTagName() string {
@@ -409,7 +413,7 @@ func (c *MJSocialElementComponent) SetVerticalMode(vertical bool) {
 }
 
 // Render implements optimized Writer-based rendering for MJSocialElementComponent
-func (c *MJSocialElementComponent) Render(w io.StringWriter) error {
+func (c *MJSocialElementComponent) RenderHTML(w io.StringWriter) error {
 	padding := c.getAttribute("padding")
 	iconSize := c.getAttribute("icon-size")
 	iconHeight := c.getAttribute("icon-height")
@@ -710,7 +714,7 @@ func (c *MJSocialElementComponent) Render(w io.StringWriter) error {
 		return err
 	}
 
-	// Render text content if present - INSIDE the same <tr>
+	// RenderHTML text content if present - INSIDE the same <tr>
 	// Use GetMixedContent to preserve HTML tags like <b>, <i>, etc. within text
 	textContent := c.Node.GetMixedContent()
 	debug.DebugLogWithData(
@@ -794,6 +798,10 @@ func (c *MJSocialElementComponent) Render(w io.StringWriter) error {
 	}
 
 	return nil
+}
+
+func (c *MJSocialElementComponent) RenderMJML(w io.StringWriter) error {
+	return &NotImplementedError{ComponentName: "mj-social-element"}
 }
 
 func (c *MJSocialElementComponent) GetTagName() string {

--- a/mjml/components/spacer.go
+++ b/mjml/components/spacer.go
@@ -18,13 +18,17 @@ func NewMJSpacerComponent(node *parser.MJMLNode, opts *options.RenderOpts) *MJSp
 	}
 }
 
-func (c *MJSpacerComponent) Render(w io.StringWriter) error {
+func (c *MJSpacerComponent) RenderHTML(w io.StringWriter) error {
 	// TODO: Implement mj-spacer component functionality
 	return &NotImplementedError{ComponentName: "mj-spacer"}
 }
 
 func (c *MJSpacerComponent) GetTagName() string {
 	return "mj-spacer"
+}
+
+func (c *MJSpacerComponent) RenderMJML(w io.StringWriter) error {
+	return &NotImplementedError{ComponentName: "mj-spacer"}
 }
 
 func (c *MJSpacerComponent) GetDefaultAttribute(name string) string {

--- a/mjml/components/table.go
+++ b/mjml/components/table.go
@@ -19,13 +19,17 @@ func NewMJTableComponent(node *parser.MJMLNode, opts *options.RenderOpts) *MJTab
 	}
 }
 
-func (c *MJTableComponent) Render(w io.StringWriter) error {
+func (c *MJTableComponent) RenderHTML(w io.StringWriter) error {
 	// TODO: Implement mj-table component functionality
 	return &NotImplementedError{ComponentName: "mj-table"}
 }
 
 func (c *MJTableComponent) GetTagName() string {
 	return "mj-table"
+}
+
+func (c *MJTableComponent) RenderMJML(w io.StringWriter) error {
+	return &NotImplementedError{ComponentName: "mj-table"}
 }
 
 func (c *MJTableComponent) GetDefaultAttribute(name string) string {

--- a/mjml/components/text.go
+++ b/mjml/components/text.go
@@ -29,7 +29,7 @@ func (c *MJTextComponent) GetTagName() string {
 }
 
 // Render implements optimized Writer-based rendering for MJTextComponent
-func (c *MJTextComponent) Render(w io.StringWriter) error {
+func (c *MJTextComponent) RenderHTML(w io.StringWriter) error {
 	debug.DebugLog("mj-text", "render-start", "Starting text component rendering")
 
 	debug.DebugLogWithData("mj-text", "content", "Processing text content", map[string]interface{}{
@@ -149,6 +149,10 @@ func (c *MJTextComponent) Render(w io.StringWriter) error {
 	}
 
 	return nil
+}
+
+func (c *MJTextComponent) RenderMJML(w io.StringWriter) error {
+	return &NotImplementedError{ComponentName: "mj-text"}
 }
 
 func (c *MJTextComponent) GetDefaultAttribute(name string) string {

--- a/mjml/components/text.go
+++ b/mjml/components/text.go
@@ -152,7 +152,34 @@ func (c *MJTextComponent) RenderHTML(w io.StringWriter) error {
 }
 
 func (c *MJTextComponent) RenderMJML(w io.StringWriter) error {
-	return &NotImplementedError{ComponentName: "mj-text"}
+	if _, err := w.WriteString("\n        <mj-text"); err != nil {
+		return err
+	}
+
+	// Render attributes
+	for name, value := range c.Attrs {
+		if _, err := w.WriteString(" " + name + "=\"" + value + "\""); err != nil {
+			return err
+		}
+	}
+
+	if _, err := w.WriteString(">"); err != nil {
+		return err
+	}
+
+	// Render text content - preserve original formatting from node
+	if c.Node.Text != "" {
+		// Use the text as-is to preserve original whitespace and formatting
+		if _, err := w.WriteString(c.Node.Text); err != nil {
+			return err
+		}
+	}
+
+	if _, err := w.WriteString("</mj-text>"); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (c *MJTextComponent) GetDefaultAttribute(name string) string {

--- a/mjml/components/wrapper.go
+++ b/mjml/components/wrapper.go
@@ -22,6 +22,10 @@ func NewMJWrapperComponent(node *parser.MJMLNode, opts *options.RenderOpts) *MJW
 	}
 }
 
+func (c *MJWrapperComponent) RenderMJML(w io.StringWriter) error {
+	return &NotImplementedError{ComponentName: "mj-wrapper"}
+}
+
 func (c *MJWrapperComponent) GetDefaultAttribute(name string) string {
 	switch name {
 	case "background-position":
@@ -81,7 +85,7 @@ func (c *MJWrapperComponent) isFullWidth() bool {
 }
 
 // Render implements optimized Writer-based rendering for MJWrapperComponent
-func (c *MJWrapperComponent) Render(w io.StringWriter) error {
+func (c *MJWrapperComponent) RenderHTML(w io.StringWriter) error {
 	if c.isFullWidth() {
 		return c.renderFullWidthToWriter(w)
 	}
@@ -199,10 +203,10 @@ func (c *MJWrapperComponent) renderFullWidthToWriter(w io.StringWriter) error {
 		return err
 	}
 
-	// Render children with standard body width
+	// RenderHTML children with standard body width
 	for _, child := range c.Children {
 		child.SetContainerWidth(GetDefaultBodyWidthPixels())
-		if err := child.Render(w); err != nil {
+		if err := child.RenderHTML(w); err != nil {
 			return err
 		}
 	}
@@ -360,10 +364,10 @@ func (c *MJWrapperComponent) renderSimpleToWriter(w io.StringWriter) error {
 		return err
 	}
 
-	// Render children - pass the effective width (600px - border width)
+	// RenderHTML children - pass the effective width (600px - border width)
 	for _, child := range c.Children {
 		child.SetContainerWidth(effectiveWidth)
-		if err := child.Render(w); err != nil {
+		if err := child.RenderHTML(w); err != nil {
 			return err
 		}
 	}

--- a/mjml/group_children_width_calculation_test.go
+++ b/mjml/group_children_width_calculation_test.go
@@ -24,12 +24,12 @@ func TestGroupChildrenWidthCalculation(t *testing.T) {
 			mjmlBuilder.WriteString(`</mj-group></mj-section></mj-body></mjml>`)
 			mjmlInput := mjmlBuilder.String()
 
-			// Render the MJML
+			// RenderHTML the MJML
 			renderResult, err := RenderWithAST(mjmlInput)
 			if err != nil {
 				t.Fatalf("Failed to render MJML: %v", err)
 			}
-			htmlOutput := renderResult.HTML
+			htmlOutput := renderResult.Result
 
 			// Extract expected CSS class from the AST instead of manually calculating
 			expectedClasses := extractColumnClassesFromAST(renderResult.AST)

--- a/mjml/integration_test.go
+++ b/mjml/integration_test.go
@@ -8,89 +8,91 @@ import (
 	"testing"
 
 	"github.com/PuerkitoBio/goquery"
+	"github.com/preslavrachev/gomjml/mjml/options"
 )
 
 // TestMJMLAgainstExpected compares Go implementation output with pre-generated expected HTML
 func TestMJMLAgainstExpected(t *testing.T) {
 	testCases := []struct {
-		name     string
-		filename string
+		name              string
+		filename          string
+		testMJMLRoundTrip bool // Set to true to enable MJML round-trip test for this specific test case
 	}{
-		{"basic", "testdata/basic.mjml"},
-		{"with-head", "testdata/with-head.mjml"},
-		{"complex-layout", "testdata/complex-layout.mjml"},
-		{"wrapper-basic", "testdata/wrapper-basic.mjml"},
-		{"wrapper-background", "testdata/wrapper-background.mjml"},
-		{"wrapper-fullwidth", "testdata/wrapper-fullwidth.mjml"},
-		{"wrapper-border", "testdata/wrapper-border.mjml"},
-		{"group-footer-test", "testdata/group-footer-test.mjml"},
-		{"section-padding-top-zero", "testdata/section-padding-top-zero.mjml"},
-		//{"Austin layout from the MJML.io site", "testdata/austin-layout-from-mjml-io.mjml"},
+		{name: "basic", filename: "testdata/basic.mjml", testMJMLRoundTrip: false},
+		{name: "with-head", filename: "testdata/with-head.mjml", testMJMLRoundTrip: false},
+		{name: "complex-layout", filename: "testdata/complex-layout.mjml", testMJMLRoundTrip: false},
+		{name: "wrapper-basic", filename: "testdata/wrapper-basic.mjml", testMJMLRoundTrip: false},
+		{name: "wrapper-background", filename: "testdata/wrapper-background.mjml", testMJMLRoundTrip: false},
+		{name: "wrapper-fullwidth", filename: "testdata/wrapper-fullwidth.mjml", testMJMLRoundTrip: false},
+		{name: "wrapper-border", filename: "testdata/wrapper-border.mjml", testMJMLRoundTrip: false},
+		{name: "group-footer-test", filename: "testdata/group-footer-test.mjml", testMJMLRoundTrip: false},
+		{name: "section-padding-top-zero", filename: "testdata/section-padding-top-zero.mjml", testMJMLRoundTrip: false},
+		//{name: "Austin layout from the MJML.io site", filename: "testdata/austin-layout-from-mjml-io.mjml", testMJMLRoundTrip: false},
 		// Austin layout component tests
-		{"austin-header-section", "testdata/austin-header-section.mjml"},
-		{"austin-hero-images", "testdata/austin-hero-images.mjml"},
-		{"austin-wrapper-basic", "testdata/austin-wrapper-basic.mjml"},
-		{"austin-text-with-links", "testdata/austin-text-with-links.mjml"},
-		{"austin-buttons", "testdata/austin-buttons.mjml"},
-		{"austin-two-column-images", "testdata/austin-two-column-images.mjml"},
-		{"austin-divider", "testdata/austin-divider.mjml"},
-		{"austin-two-column-text", "testdata/austin-two-column-text.mjml"},
-		{"austin-full-width-wrapper", "testdata/austin-full-width-wrapper.mjml"},
-		//{"austin-social-media", "testdata/austin-social-media.mjml"},
-		{"austin-footer-text", "testdata/austin-footer-text.mjml"},
-		{"austin-group-component", "testdata/austin-group-component.mjml"},
-		{"austin-global-attributes", "testdata/austin-global-attributes.mjml"},
-		{"austin-map-image", "testdata/austin-map-image.mjml"},
+		{name: "austin-header-section", filename: "testdata/austin-header-section.mjml", testMJMLRoundTrip: false},
+		{name: "austin-hero-images", filename: "testdata/austin-hero-images.mjml", testMJMLRoundTrip: false},
+		{name: "austin-wrapper-basic", filename: "testdata/austin-wrapper-basic.mjml", testMJMLRoundTrip: false},
+		{name: "austin-text-with-links", filename: "testdata/austin-text-with-links.mjml", testMJMLRoundTrip: false},
+		{name: "austin-buttons", filename: "testdata/austin-buttons.mjml", testMJMLRoundTrip: false},
+		{name: "austin-two-column-images", filename: "testdata/austin-two-column-images.mjml", testMJMLRoundTrip: false},
+		{name: "austin-divider", filename: "testdata/austin-divider.mjml", testMJMLRoundTrip: false},
+		{name: "austin-two-column-text", filename: "testdata/austin-two-column-text.mjml", testMJMLRoundTrip: false},
+		{name: "austin-full-width-wrapper", filename: "testdata/austin-full-width-wrapper.mjml", testMJMLRoundTrip: false},
+		//{name: "austin-social-media", filename: "testdata/austin-social-media.mjml", testMJMLRoundTrip: false},
+		{name: "austin-footer-text", filename: "testdata/austin-footer-text.mjml", testMJMLRoundTrip: false},
+		{name: "austin-group-component", filename: "testdata/austin-group-component.mjml", testMJMLRoundTrip: false},
+		{name: "austin-global-attributes", filename: "testdata/austin-global-attributes.mjml", testMJMLRoundTrip: false},
+		{name: "austin-map-image", filename: "testdata/austin-map-image.mjml", testMJMLRoundTrip: false},
 		// MRML reference tests
-		{"mrml-divider-basic", "testdata/mrml-divider-basic.mjml"},
-		{"mrml-text-basic", "testdata/mrml-text-basic.mjml"},
-		{"mrml-button-basic", "testdata/mrml-button-basic.mjml"},
-		{"body-wrapper-section", "testdata/body-wrapper-section.mjml"},
+		{name: "mrml-divider-basic", filename: "testdata/mrml-divider-basic.mjml", testMJMLRoundTrip: false},
+		{name: "mrml-text-basic", filename: "testdata/mrml-text-basic.mjml", testMJMLRoundTrip: false},
+		{name: "mrml-button-basic", filename: "testdata/mrml-button-basic.mjml", testMJMLRoundTrip: false},
+		{name: "body-wrapper-section", filename: "testdata/body-wrapper-section.mjml", testMJMLRoundTrip: false},
 		// MJ-Group tests from MRML
-		{"mj-group", "testdata/mj-group.mjml"},
-		{"mj-group-background-color", "testdata/mj-group-background-color.mjml"},
-		{"mj-group-class", "testdata/mj-group-class.mjml"},
-		{"mj-group-direction", "testdata/mj-group-direction.mjml"},
-		{"mj-group-vertical-align", "testdata/mj-group-vertical-align.mjml"},
-		{"mj-group-width", "testdata/mj-group-width.mjml"},
+		{name: "mj-group", filename: "testdata/mj-group.mjml", testMJMLRoundTrip: false},
+		{name: "mj-group-background-color", filename: "testdata/mj-group-background-color.mjml", testMJMLRoundTrip: false},
+		{name: "mj-group-class", filename: "testdata/mj-group-class.mjml", testMJMLRoundTrip: false},
+		{name: "mj-group-direction", filename: "testdata/mj-group-direction.mjml", testMJMLRoundTrip: false},
+		{name: "mj-group-vertical-align", filename: "testdata/mj-group-vertical-align.mjml", testMJMLRoundTrip: false},
+		{name: "mj-group-width", filename: "testdata/mj-group-width.mjml", testMJMLRoundTrip: false},
 		// Simple MJML components from MRML test suite
-		{"mj-text", "testdata/mj-text.mjml"},
-		{"mj-text-class", "testdata/mj-text-class.mjml"},
-		{"mj-button", "testdata/mj-button.mjml"},
-		{"mj-button-class", "testdata/mj-button-class.mjml"},
-		{"mj-image", "testdata/mj-image.mjml"},
-		{"mj-image-class", "testdata/mj-image-class.mjml"},
-		{"mj-section-with-columns", "testdata/mj-section-with-columns.mjml"},
-		{"mj-section", "testdata/mj-section.mjml"},
-		{"mj-section-class", "testdata/mj-section-class.mjml"},
-		{"mj-column", "testdata/mj-column.mjml"},
-		{"mj-column-padding", "testdata/mj-column-padding.mjml"},
-		{"mj-column-class", "testdata/mj-column-class.mjml"},
-		{"mj-wrapper", "testdata/mj-wrapper.mjml"},
+		{name: "mj-text", filename: "testdata/mj-text.mjml", testMJMLRoundTrip: false},
+		{name: "mj-text-class", filename: "testdata/mj-text-class.mjml", testMJMLRoundTrip: false},
+		{name: "mj-button", filename: "testdata/mj-button.mjml", testMJMLRoundTrip: false},
+		{name: "mj-button-class", filename: "testdata/mj-button-class.mjml", testMJMLRoundTrip: false},
+		{name: "mj-image", filename: "testdata/mj-image.mjml", testMJMLRoundTrip: false},
+		{name: "mj-image-class", filename: "testdata/mj-image-class.mjml", testMJMLRoundTrip: false},
+		{name: "mj-section-with-columns", filename: "testdata/mj-section-with-columns.mjml", testMJMLRoundTrip: false},
+		{name: "mj-section", filename: "testdata/mj-section.mjml", testMJMLRoundTrip: false},
+		{name: "mj-section-class", filename: "testdata/mj-section-class.mjml", testMJMLRoundTrip: false},
+		{name: "mj-column", filename: "testdata/mj-column.mjml", testMJMLRoundTrip: false},
+		{name: "mj-column-padding", filename: "testdata/mj-column-padding.mjml", testMJMLRoundTrip: false},
+		{name: "mj-column-class", filename: "testdata/mj-column-class.mjml", testMJMLRoundTrip: false},
+		{name: "mj-wrapper", filename: "testdata/mj-wrapper.mjml", testMJMLRoundTrip: false},
 		// MJ-RAW tests
-		{"mj-raw", "testdata/mj-raw.mjml"},
-		{"mj-raw-conditional-comment", "testdata/mj-raw-conditional-comment.mjml"},
-		{"mj-raw-go-template", "testdata/mj-raw-go-template.mjml"},
+		{name: "mj-raw", filename: "testdata/mj-raw.mjml", testMJMLRoundTrip: false},
+		{name: "mj-raw-conditional-comment", filename: "testdata/mj-raw-conditional-comment.mjml", testMJMLRoundTrip: false},
+		{name: "mj-raw-go-template", filename: "testdata/mj-raw-go-template.mjml", testMJMLRoundTrip: false},
 		// MJ-SOCIAL tests
-		{"mj-social", "testdata/mj-social.mjml"},
-		{"mj-social-align", "testdata/mj-social-align.mjml"},
-		{"mj-social-border-radius", "testdata/mj-social-border-radius.mjml"},
-		{"mj-social-class", "testdata/mj-social-class.mjml"},
-		{"mj-social-color", "testdata/mj-social-color.mjml"},
-		{"mj-social-container-background-color", "testdata/mj-social-container-background-color.mjml"},
-		{"mj-social-element-ending", "testdata/mj-social-element-ending.mjml"},
-		{"mj-social-font-family", "testdata/mj-social-font-family.mjml"},
-		{"mj-social-font", "testdata/mj-social-font.mjml"},
-		{"mj-social-icon", "testdata/mj-social-icon.mjml"},
-		{"mj-social-link", "testdata/mj-social-link.mjml"},
-		{"mj-social-mode", "testdata/mj-social-mode.mjml"},
-		{"mj-social-padding", "testdata/mj-social-padding.mjml"},
-		{"mj-social-text", "testdata/mj-social-text.mjml"},
+		{name: "mj-social", filename: "testdata/mj-social.mjml", testMJMLRoundTrip: false},
+		{name: "mj-social-align", filename: "testdata/mj-social-align.mjml", testMJMLRoundTrip: false},
+		{name: "mj-social-border-radius", filename: "testdata/mj-social-border-radius.mjml", testMJMLRoundTrip: false},
+		{name: "mj-social-class", filename: "testdata/mj-social-class.mjml", testMJMLRoundTrip: false},
+		{name: "mj-social-color", filename: "testdata/mj-social-color.mjml", testMJMLRoundTrip: false},
+		{name: "mj-social-container-background-color", filename: "testdata/mj-social-container-background-color.mjml", testMJMLRoundTrip: false},
+		{name: "mj-social-element-ending", filename: "testdata/mj-social-element-ending.mjml", testMJMLRoundTrip: false},
+		{name: "mj-social-font-family", filename: "testdata/mj-social-font-family.mjml", testMJMLRoundTrip: false},
+		{name: "mj-social-font", filename: "testdata/mj-social-font.mjml", testMJMLRoundTrip: false},
+		{name: "mj-social-icon", filename: "testdata/mj-social-icon.mjml", testMJMLRoundTrip: false},
+		{name: "mj-social-link", filename: "testdata/mj-social-link.mjml", testMJMLRoundTrip: false},
+		{name: "mj-social-mode", filename: "testdata/mj-social-mode.mjml", testMJMLRoundTrip: false},
+		{name: "mj-social-padding", filename: "testdata/mj-social-padding.mjml", testMJMLRoundTrip: false},
+		{name: "mj-social-text", filename: "testdata/mj-social-text.mjml", testMJMLRoundTrip: false},
 		// MJ-ACCORDION tests (commented out - need implementation)
-		{"mj-accordion", "testdata/mj-accordion.mjml"},
-		{"mj-accordion-font-padding", "testdata/mj-accordion-font-padding.mjml"},
-		{"mj-accordion-icon", "testdata/mj-accordion-icon.mjml"},
-		{"mj-accordion-other", "testdata/mj-accordion-other.mjml"},
+		{name: "mj-accordion", filename: "testdata/mj-accordion.mjml", testMJMLRoundTrip: false},
+		{name: "mj-accordion-font-padding", filename: "testdata/mj-accordion-font-padding.mjml", testMJMLRoundTrip: false},
+		{name: "mj-accordion-icon", filename: "testdata/mj-accordion-icon.mjml", testMJMLRoundTrip: false},
+		{name: "mj-accordion-other", filename: "testdata/mj-accordion-other.mjml", testMJMLRoundTrip: false},
 	}
 
 	for _, tc := range testCases {
@@ -113,7 +115,7 @@ func TestMJMLAgainstExpected(t *testing.T) {
 					)
 
 					// Just verify our implementation doesn't crash and produces some output
-					actual, err := Render(string(mjmlContent))
+					actual, err := RenderHTML(string(mjmlContent))
 					if err != nil {
 						t.Fatalf("Failed to render MJML: %v", err)
 					}
@@ -140,7 +142,7 @@ func TestMJMLAgainstExpected(t *testing.T) {
 			expected := string(expectedContent)
 
 			// Get actual output from Go implementation (direct library usage)
-			actual, err := Render(string(mjmlContent))
+			actual, err := RenderHTML(string(mjmlContent))
 			if err != nil {
 				t.Fatalf("Failed to render MJML: %v", err)
 			}
@@ -159,10 +161,16 @@ func TestMJMLAgainstExpected(t *testing.T) {
 				os.WriteFile("/tmp/expected_"+tc.name+".html", []byte(expected), 0o644)
 				os.WriteFile("/tmp/actual_"+tc.name+".html", []byte(actual), 0o644)
 			}
+
+			// MJML round-trip test (if enabled for this test case)
+			if tc.testMJMLRoundTrip {
+				t.Run(tc.name+"_mjml_roundtrip", func(t *testing.T) {
+					runMJMLRoundTripTest(t, string(mjmlContent), tc.name)
+				})
+			}
 		})
 	}
 }
-
 
 // TestDirectLibraryUsage demonstrates and tests direct library usage
 func TestDirectLibraryUsage(t *testing.T) {
@@ -177,7 +185,7 @@ func TestDirectLibraryUsage(t *testing.T) {
 	</mjml>`
 
 	// Test direct library usage as documented in the restructuring plan
-	html, err := Render(mjmlInput)
+	html, err := RenderHTML(mjmlInput)
 	if err != nil {
 		t.Fatalf("Direct library usage failed: %v", err)
 	}
@@ -212,10 +220,10 @@ func TestComponentCreation(t *testing.T) {
 		t.Fatalf("NewFromAST failed: %v", err)
 	}
 
-	// Render to HTML
+	// RenderHTML to HTML
 	html, err := RenderComponentString(component)
 	if err != nil {
-		t.Fatalf("Render failed: %v", err)
+		t.Fatalf("RenderHTML failed: %v", err)
 	}
 
 	// Verify output
@@ -946,4 +954,85 @@ func normalizeCSSContent(css string) string {
 	})
 
 	return string(runes)
+}
+
+// runMJMLRoundTripTest tests MJML round-trip: MJML -> AST -> MJML and compares with original
+func runMJMLRoundTripTest(t *testing.T, originalMJML, testName string) {
+	// Parse original MJML to AST
+	ast, err := ParseMJML(originalMJML)
+	if err != nil {
+		t.Fatalf("Failed to parse MJML for round-trip test: %v", err)
+	}
+
+	// Render AST back to MJML
+	renderedMJML, err := RenderFromAST(ast, WithOutputFormat(options.OutputMJML))
+	if err != nil {
+		t.Fatalf("Failed to render AST to MJML: %v", err)
+	}
+
+	// Compare original and rendered MJML
+	if !compareMJMLContent(originalMJML, renderedMJML) {
+		t.Errorf("MJML round-trip failed for %s", testName)
+		t.Logf("Original MJML length: %d", len(originalMJML))
+		t.Logf("Rendered MJML length: %d", len(renderedMJML))
+
+		// Write both to temp files for debugging
+		os.WriteFile("/tmp/original_"+testName+".mjml", []byte(originalMJML), 0o644)
+		os.WriteFile("/tmp/rendered_"+testName+".mjml", []byte(renderedMJML), 0o644)
+
+		// Show first difference
+		showMJMLDiff(t, originalMJML, renderedMJML, testName)
+	}
+}
+
+// compareMJMLContent compares two MJML strings, normalizing whitespace and structure
+func compareMJMLContent(original, rendered string) bool {
+	// Basic normalization - remove extra whitespace, normalize line endings
+	normalizeWhitespace := func(s string) string {
+		// Normalize line endings
+		s = strings.ReplaceAll(s, "\r\n", "\n")
+		s = strings.ReplaceAll(s, "\r", "\n")
+
+		// Split into lines and trim each
+		lines := strings.Split(s, "\n")
+		var normalizedLines []string
+		for _, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			if trimmed != "" {
+				normalizedLines = append(normalizedLines, trimmed)
+			}
+		}
+
+		return strings.Join(normalizedLines, "\n")
+	}
+
+	normalizedOriginal := normalizeWhitespace(original)
+	normalizedRendered := normalizeWhitespace(rendered)
+
+	return normalizedOriginal == normalizedRendered
+}
+
+// showMJMLDiff shows the first significant difference between original and rendered MJML
+func showMJMLDiff(t *testing.T, original, rendered, testName string) {
+	originalLines := strings.Split(original, "\n")
+	renderedLines := strings.Split(rendered, "\n")
+
+	maxLines := max(len(originalLines), len(renderedLines))
+
+	for i := 0; i < maxLines; i++ {
+		var origLine, rendLine string
+		if i < len(originalLines) {
+			origLine = strings.TrimSpace(originalLines[i])
+		}
+		if i < len(renderedLines) {
+			rendLine = strings.TrimSpace(renderedLines[i])
+		}
+
+		if origLine != rendLine {
+			t.Logf("First difference at line %d:", i+1)
+			t.Logf("  Original: %q", origLine)
+			t.Logf("  Rendered: %q", rendLine)
+			break
+		}
+	}
 }

--- a/mjml/integration_test.go
+++ b/mjml/integration_test.go
@@ -18,7 +18,7 @@ func TestMJMLAgainstExpected(t *testing.T) {
 		filename          string
 		testMJMLRoundTrip bool // Set to true to enable MJML round-trip test for this specific test case
 	}{
-		{name: "basic", filename: "testdata/basic.mjml", testMJMLRoundTrip: false},
+		{name: "basic", filename: "testdata/basic.mjml", testMJMLRoundTrip: true},
 		{name: "with-head", filename: "testdata/with-head.mjml", testMJMLRoundTrip: false},
 		{name: "complex-layout", filename: "testdata/complex-layout.mjml", testMJMLRoundTrip: false},
 		{name: "wrapper-basic", filename: "testdata/wrapper-basic.mjml", testMJMLRoundTrip: false},

--- a/mjml/mjml_basic_html_templating_test.go
+++ b/mjml/mjml_basic_html_templating_test.go
@@ -52,7 +52,7 @@ func TestMJRawWithGoTemplate(t *testing.T) {
 	}
 
 	// Convert templated MJML to HTML using gomjml
-	finalHTML, err := Render(templatedMJML.String())
+	finalHTML, err := RenderHTML(templatedMJML.String())
 	if err != nil {
 		t.Fatalf("Failed to render MJML: %v", err)
 	}

--- a/mjml/mjml_test.go
+++ b/mjml/mjml_test.go
@@ -66,23 +66,23 @@ func TestRender(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			html, err := Render(tt.input)
+			html, err := RenderHTML(tt.input)
 
 			if tt.wantErr {
 				if err == nil {
-					t.Errorf("Render() expected error but got none")
+					t.Errorf("RenderHTML() expected error but got none")
 				}
 				return
 			}
 
 			if err != nil {
-				t.Errorf("Render() error = %v", err)
+				t.Errorf("RenderHTML() error = %v", err)
 				return
 			}
 
 			for _, want := range tt.contains {
 				if !strings.Contains(html, want) {
-					t.Errorf("Render() output should contain %q", want)
+					t.Errorf("RenderHTML() output should contain %q", want)
 				}
 			}
 		})
@@ -108,10 +108,10 @@ func TestCreateComponent(t *testing.T) {
 	// Test rendering
 	html, err := RenderComponentString(comp)
 	if err != nil {
-		t.Fatalf("Render() error = %v", err)
+		t.Fatalf("RenderHTML() error = %v", err)
 	}
 
 	if !strings.Contains(html, "Hello") {
-		t.Errorf("Render() output should contain 'Hello'")
+		t.Errorf("RenderHTML() output should contain 'Hello'")
 	}
 }

--- a/mjml/options/options.go
+++ b/mjml/options/options.go
@@ -3,6 +3,14 @@ package options
 
 import "sync"
 
+// OutputFormat specifies the output format for rendering
+type OutputFormat int
+
+const (
+	OutputHTML OutputFormat = iota // Default HTML rendering
+	OutputMJML                     // MJML rendering
+)
+
 // FontTracker tracks font families used by components during rendering
 type FontTracker struct {
 	mu    sync.Mutex
@@ -41,7 +49,8 @@ func (ft *FontTracker) GetFonts() []string {
 
 // RenderOpts contains options for MJML rendering
 type RenderOpts struct {
-	DebugTags   bool         // Whether to include debug attributes in output
-	InsideGroup bool         // Whether the component is being rendered inside a group
-	FontTracker *FontTracker // Tracks fonts used during rendering
+	DebugTags    bool         // Whether to include debug attributes in output
+	InsideGroup  bool         // Whether the component is being rendered inside a group
+	FontTracker  *FontTracker // Tracks fonts used during rendering
+	OutputFormat OutputFormat // Output format (HTML=0 default, MJML=1)
 }

--- a/mjml/preallocation_benchmark_test.go
+++ b/mjml/preallocation_benchmark_test.go
@@ -160,9 +160,9 @@ func BenchmarkPreallocationStrategies_Simple(b *testing.B) {
 
 				var buf strings.Builder
 				buf.Grow(bufferSize) // Pre-allocate with strategy
-				err = component.Render(&buf)
+				err = component.RenderHTML(&buf)
 				if err != nil {
-					b.Fatalf("Render failed: %v", err)
+					b.Fatalf("RenderHTML failed: %v", err)
 				}
 				_ = buf.String() // Force evaluation
 			}
@@ -195,9 +195,9 @@ func BenchmarkPreallocationStrategies_Medium(b *testing.B) {
 
 				var buf strings.Builder
 				buf.Grow(bufferSize) // Pre-allocate with strategy
-				err = component.Render(&buf)
+				err = component.RenderHTML(&buf)
 				if err != nil {
-					b.Fatalf("Render failed: %v", err)
+					b.Fatalf("RenderHTML failed: %v", err)
 				}
 				_ = buf.String() // Force evaluation
 			}
@@ -230,9 +230,9 @@ func BenchmarkPreallocationStrategies_Complex(b *testing.B) {
 
 				var buf strings.Builder
 				buf.Grow(bufferSize) // Pre-allocate with strategy
-				err = component.Render(&buf)
+				err = component.RenderHTML(&buf)
 				if err != nil {
-					b.Fatalf("Render failed: %v", err)
+					b.Fatalf("RenderHTML failed: %v", err)
 				}
 				_ = buf.String() // Force evaluation
 			}
@@ -266,9 +266,9 @@ func BenchmarkPreallocationStrategies_RealWorld(b *testing.B) {
 
 				var buf strings.Builder
 				buf.Grow(bufferSize) // Pre-allocate with strategy
-				err = component.Render(&buf)
+				err = component.RenderHTML(&buf)
 				if err != nil {
-					b.Fatalf("Render failed: %v", err)
+					b.Fatalf("RenderHTML failed: %v", err)
 				}
 				_ = buf.String() // Force evaluation
 			}
@@ -304,9 +304,9 @@ func BenchmarkBufferGrowth_Analysis(b *testing.B) {
 
 				// No pre-allocation to see natural growth
 				var buf strings.Builder
-				err = component.Render(&buf)
+				err = component.RenderHTML(&buf)
 				if err != nil {
-					b.Fatalf("Render failed: %v", err)
+					b.Fatalf("RenderHTML failed: %v", err)
 				}
 
 				result := buf.String()
@@ -338,9 +338,9 @@ func TestExpansionRatios(t *testing.T) {
 			}
 
 			var buf strings.Builder
-			err = component.Render(&buf)
+			err = component.RenderHTML(&buf)
 			if err != nil {
-				t.Fatalf("Render failed: %v", err)
+				t.Fatalf("RenderHTML failed: %v", err)
 			}
 
 			result := buf.String()

--- a/mjml/render.go
+++ b/mjml/render.go
@@ -841,5 +841,27 @@ func (c *MJMLComponent) RenderHTML(w io.StringWriter) error {
 }
 
 func (c *MJMLComponent) RenderMJML(w io.StringWriter) error {
-	return &components.NotImplementedError{ComponentName: "mjml"}
+	if _, err := w.WriteString("<mjml>"); err != nil {
+		return err
+	}
+
+	// Render head if present
+	if c.Head != nil {
+		if err := c.Head.RenderMJML(w); err != nil {
+			return err
+		}
+	}
+
+	// Render body if present
+	if c.Body != nil {
+		if err := c.Body.RenderMJML(w); err != nil {
+			return err
+		}
+	}
+
+	if _, err := w.WriteString("\n</mjml>"); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -170,7 +170,7 @@ func (n *MJMLNode) GetMixedContent() string {
 
 	// Add child elements with remaining text parts
 	for i, child := range n.Children {
-		// Render child element as HTML
+		// RenderHTML child element as HTML
 		result.WriteString("<")
 		result.WriteString(child.XMLName.Local)
 


### PR DESCRIPTION
This addition extends the existing implementation with back-to-back rendering of MJML=>AST=>HTML/MJML. 

Why do we want the AST to render MJML back? Isn't the MJML content sort of the input that we are given anyway? 

In most cases, yes, but imagine the following: having the MJML AST in Go code opens up new possibilities, one of which is generating Go code out of some MJML, and using the Go code as the one and only way we render email templates. This would be great, but until now, it wouldn't be able to verify and validate the MJML code out of the Go code. We either had to store both versions (leads to duplication and possible inconsistencies) or rely on never changing the generated Go code. If you did want to change it, however (e.g., include some loops, conditional logic, etc.), you would need a way to see the MJML this new Go code would generate - it's just way easier to [debug MJML code](https://mjml.io/try-it-live) than having to debug its generated HTML output.