### PR TITLE
Add support for mj-hero component

### DIFF
--- a/mjml/component.go
+++ b/mjml/component.go
@@ -150,6 +150,9 @@ func createMJMLComponent(node *parser.MJMLNode, opts *options.RenderOpts) (*MJML
 						}
 					}
 				}
+			case *components.MJHeroComponent:
+				// Process hero children
+				processComponentChildren(comp, comp.Node, opts)
 			}
 		}
 	}
@@ -186,6 +189,13 @@ func processComponentChildren(component Component, node *parser.MJMLNode, opts *
 		}
 	case *components.MJNavbarComponent:
 		// Process navbar link children
+		for _, childNode := range node.Children {
+			if childComponent, err := CreateComponent(childNode, opts); err == nil {
+				comp.Children = append(comp.Children, childComponent)
+			}
+		}
+	case *components.MJHeroComponent:
+		// Process hero children
 		for _, childNode := range node.Children {
 			if childComponent, err := CreateComponent(childNode, opts); err == nil {
 				comp.Children = append(comp.Children, childComponent)

--- a/mjml/components/button.go
+++ b/mjml/components/button.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/preslavrachev/gomjml/mjml/constants"
 	"github.com/preslavrachev/gomjml/mjml/fonts"
 	"github.com/preslavrachev/gomjml/mjml/html"
 	"github.com/preslavrachev/gomjml/mjml/options"
@@ -114,7 +115,7 @@ func (c *MJButtonComponent) Render(w io.StringWriter) error {
 	// Only add vertical-align attribute if not inside an mj-hero
 	// In mj-hero context, MRML doesn't include this attribute
 	if !c.RenderOpts.InsideHero {
-		tdTag.AddAttribute("vertical-align", verticalAlign)
+		tdTag.AddAttribute(constants.AttrVerticalAlign, verticalAlign)
 	}
 
 	tdTag.AddStyle("font-size", "0px").
@@ -157,7 +158,7 @@ func (c *MJButtonComponent) Render(w io.StringWriter) error {
 	// Button cell with background and border styles
 	buttonTdTag := html.NewHTMLTag("td").
 		AddAttribute("align", "center").
-		AddAttribute("bgcolor", backgroundColor).
+		AddAttribute(constants.AttrBgcolor, backgroundColor).
 		AddAttribute("role", "presentation").
 		AddAttribute("valign", verticalAlign).
 		AddStyle("border", border).

--- a/mjml/components/button.go
+++ b/mjml/components/button.go
@@ -109,9 +109,15 @@ func (c *MJButtonComponent) Render(w io.StringWriter) error {
 
 	// Create TD with alignment and base styles
 	tdTag := html.NewHTMLTag("td").
-		AddAttribute("align", align).
-		AddAttribute("vertical-align", verticalAlign).
-		AddStyle("font-size", "0px").
+		AddAttribute("align", align)
+
+	// Only add vertical-align attribute if not inside an mj-hero
+	// In mj-hero context, MRML doesn't include this attribute
+	if !c.RenderOpts.InsideHero {
+		tdTag.AddAttribute("vertical-align", verticalAlign)
+	}
+
+	tdTag.AddStyle("font-size", "0px").
 		AddStyle("padding", padding).
 		AddStyle("word-break", "break-word")
 

--- a/mjml/components/hero.go
+++ b/mjml/components/hero.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/preslavrachev/gomjml/mjml/constants"
 	"github.com/preslavrachev/gomjml/mjml/html"
 	"github.com/preslavrachev/gomjml/mjml/options"
 	"github.com/preslavrachev/gomjml/parser"
@@ -31,14 +32,14 @@ func (c *MJHeroComponent) Render(w io.StringWriter) error {
 	}
 
 	// Get attributes
-	backgroundColor := getAttr("background-color")
-	backgroundPosition := getAttr("background-position")
-	backgroundRepeat := "no-repeat"
-	backgroundUrl := getAttr("background-url")
-	backgroundHeight := getAttr("background-height")
-	height := getAttr("height")
-	padding := getAttr("padding")
-	verticalAlign := getAttr("vertical-align")
+	backgroundColor := getAttr(constants.MJMLBackgroundColor)
+	backgroundPosition := getAttr(constants.MJMLBackgroundPosition)
+	backgroundRepeat := constants.BackgroundRepeatNoRepeat
+	backgroundUrl := getAttr(constants.MJMLBackgroundUrl)
+	backgroundHeight := getAttr(constants.MJMLBackgroundHeight)
+	height := getAttr(constants.MJMLHeight)
+	padding := getAttr(constants.MJMLPadding)
+	verticalAlign := getAttr(constants.MJMLVerticalAlign)
 
 	// Calculate effective height by subtracting padding
 	effectiveHeight := height
@@ -85,69 +86,74 @@ func (c *MJHeroComponent) Render(w io.StringWriter) error {
 		return err
 	}
 
-	// Main responsive container
-	if _, err := w.WriteString(`<div`); err != nil {
-		return err
-	}
+	// Main responsive container using HTMLTag builder
+	divTag := html.NewHTMLTag("div").
+		AddStyle(constants.CSSMargin, "0 auto").
+		AddStyle(constants.CSSMaxWidth, containerWidthPx)
 
 	// Add css-class if present
 	if cssClass := c.BuildClassAttribute(); cssClass != "" {
-		if _, err := w.WriteString(` class="`); err != nil {
-			return err
-		}
-		if _, err := w.WriteString(cssClass); err != nil {
-			return err
-		}
-		if _, err := w.WriteString(`"`); err != nil {
-			return err
-		}
+		divTag.AddAttribute(constants.AttrClass, cssClass)
 	}
 
-	if _, err := w.WriteString(` style="margin:0 auto;max-width:`); err != nil {
-		return err
-	}
-	if _, err := w.WriteString(containerWidthPx); err != nil {
-		return err
-	}
-	if _, err := w.WriteString(`;">`); err != nil {
+	if err := divTag.RenderOpen(w); err != nil {
 		return err
 	}
 
-	// Main table
-	if _, err := w.WriteString(`<table border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"><tbody><tr style="vertical-align:top;">`); err != nil {
+	// Main table using HTMLTag builder
+	mainTableTag := html.NewHTMLTag("table").
+		AddAttribute(constants.AttrBorder, "0").
+		AddAttribute(constants.AttrCellPadding, "0").
+		AddAttribute(constants.AttrCellSpacing, "0").
+		AddAttribute(constants.AttrRole, "presentation").
+		AddStyle(constants.CSSWidth, "100%")
+
+	if err := mainTableTag.RenderOpen(w); err != nil {
+		return err
+	}
+
+	// tbody and tr
+	tbodyTag := html.NewHTMLTag("tbody")
+	if err := tbodyTag.RenderOpen(w); err != nil {
+		return err
+	}
+
+	trTag := html.NewHTMLTag("tr").
+		AddStyle(constants.CSSVerticalAlign, constants.VAlignTop)
+	if err := trTag.RenderOpen(w); err != nil {
 		return err
 	}
 
 	// Main TD with background and height using HTMLTag builder
 	tdTag := html.NewHTMLTag("td").
-		AddAttribute("height", strings.TrimSuffix(effectiveHeight, "px")).
-		AddStyle("background", backgroundColor).
-		AddStyle("background-position", backgroundPosition).
-		AddStyle("background-repeat", backgroundRepeat).
-		AddStyle("padding", padding).
-		AddStyle("vertical-align", verticalAlign).
-		AddStyle("height", effectiveHeight)
+		AddAttribute(constants.AttrHeight, strings.TrimSuffix(effectiveHeight, "px")).
+		AddStyle(constants.CSSBackground, backgroundColor).
+		AddStyle(constants.CSSBackgroundPosition, backgroundPosition).
+		AddStyle(constants.CSSBackgroundRepeat, backgroundRepeat).
+		AddStyle(constants.CSSPadding, padding).
+		AddStyle(constants.CSSVerticalAlign, verticalAlign).
+		AddStyle(constants.CSSHeight, effectiveHeight)
 
 	// Add background image if provided
 	if backgroundUrl != "" {
-		tdTag.AddAttribute("background", backgroundUrl)
+		tdTag.AddAttribute(constants.CSSBackground, backgroundUrl)
 		// Add CSS shorthand background for modern email clients
 		shorthandBg := fmt.Sprintf("%s url('%s') %s %s / cover", backgroundColor, backgroundUrl, backgroundRepeat, backgroundPosition)
-		tdTag.AddStyle("background", shorthandBg)
+		tdTag.AddStyle(constants.CSSBackground, shorthandBg)
 	}
 
 	// Add individual padding overrides (similar to other components)
-	if paddingTopAttr := c.GetAttribute("padding-top"); paddingTopAttr != nil {
-		tdTag.AddStyle("padding-top", *paddingTopAttr)
+	if paddingTopAttr := c.GetAttribute(constants.MJMLPaddingTop); paddingTopAttr != nil {
+		tdTag.AddStyle(constants.CSSPaddingTop, *paddingTopAttr)
 	}
-	if paddingRightAttr := c.GetAttribute("padding-right"); paddingRightAttr != nil {
-		tdTag.AddStyle("padding-right", *paddingRightAttr)
+	if paddingRightAttr := c.GetAttribute(constants.MJMLPaddingRight); paddingRightAttr != nil {
+		tdTag.AddStyle(constants.CSSPaddingRight, *paddingRightAttr)
 	}
-	if paddingBottomAttr := c.GetAttribute("padding-bottom"); paddingBottomAttr != nil {
-		tdTag.AddStyle("padding-bottom", *paddingBottomAttr)
+	if paddingBottomAttr := c.GetAttribute(constants.MJMLPaddingBottom); paddingBottomAttr != nil {
+		tdTag.AddStyle(constants.CSSPaddingBottom, *paddingBottomAttr)
 	}
-	if paddingLeftAttr := c.GetAttribute("padding-left"); paddingLeftAttr != nil {
-		tdTag.AddStyle("padding-left", *paddingLeftAttr)
+	if paddingLeftAttr := c.GetAttribute(constants.MJMLPaddingLeft); paddingLeftAttr != nil {
+		tdTag.AddStyle(constants.CSSPaddingLeft, *paddingLeftAttr)
 	}
 
 	if err := tdTag.RenderOpen(w); err != nil {
@@ -164,18 +170,56 @@ func (c *MJHeroComponent) Render(w io.StringWriter) error {
 		return err
 	}
 
-	// Hero content container
-	if _, err := w.WriteString(`<div class="mj-hero-content" style="margin:0px auto;">`); err != nil {
+	// Hero content container using HTMLTag builder
+	heroContentTag := html.NewHTMLTag("div").
+		AddAttribute(constants.AttrClass, "mj-hero-content").
+		AddStyle(constants.CSSMargin, "0px auto")
+	if err := heroContentTag.RenderOpen(w); err != nil {
 		return err
 	}
 
-	// Content table structure
-	if _, err := w.WriteString(`<table border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;margin:0px;"><tbody><tr><td>`); err != nil {
+	// Content table structure using HTMLTag builder
+	contentTableTag := html.NewHTMLTag("table").
+		AddAttribute(constants.AttrBorder, "0").
+		AddAttribute(constants.AttrCellPadding, "0").
+		AddAttribute(constants.AttrCellSpacing, "0").
+		AddAttribute(constants.AttrRole, "presentation").
+		AddStyle(constants.CSSWidth, "100%").
+		AddStyle(constants.CSSMargin, "0px")
+	if err := contentTableTag.RenderOpen(w); err != nil {
 		return err
 	}
 
-	// Inner content table for children
-	if _, err := w.WriteString(`<table border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;margin:0px;"><tbody>`); err != nil {
+	// tbody, tr, td
+	contentTbodyTag := html.NewHTMLTag("tbody")
+	if err := contentTbodyTag.RenderOpen(w); err != nil {
+		return err
+	}
+
+	contentTrTag := html.NewHTMLTag("tr")
+	if err := contentTrTag.RenderOpen(w); err != nil {
+		return err
+	}
+
+	contentTdTag := html.NewHTMLTag("td")
+	if err := contentTdTag.RenderOpen(w); err != nil {
+		return err
+	}
+
+	// Inner content table for children using HTMLTag builder
+	innerTableTag := html.NewHTMLTag("table").
+		AddAttribute(constants.AttrBorder, "0").
+		AddAttribute(constants.AttrCellPadding, "0").
+		AddAttribute(constants.AttrCellSpacing, "0").
+		AddAttribute(constants.AttrRole, "presentation").
+		AddStyle(constants.CSSWidth, "100%").
+		AddStyle(constants.CSSMargin, "0px")
+	if err := innerTableTag.RenderOpen(w); err != nil {
+		return err
+	}
+
+	innerTbodyTag := html.NewHTMLTag("tbody")
+	if err := innerTbodyTag.RenderOpen(w); err != nil {
 		return err
 	}
 
@@ -205,12 +249,12 @@ func (c *MJHeroComponent) Render(w io.StringWriter) error {
 	}
 
 	// Close inner content table
-	if _, err := w.WriteString(`</tbody></table>`); err != nil {
+	if _, err := w.WriteString("</tbody></table>"); err != nil {
 		return err
 	}
 
 	// Close content structure
-	if _, err := w.WriteString(`</td></tr></tbody></table></div>`); err != nil {
+	if _, err := w.WriteString("</td></tr></tbody></table></div>"); err != nil {
 		return err
 	}
 
@@ -219,8 +263,8 @@ func (c *MJHeroComponent) Render(w io.StringWriter) error {
 		return err
 	}
 
-	// Close main TD and table
-	if _, err := w.WriteString(`</td></tr></tbody></table></div>`); err != nil {
+	// Close main TD, tr, tbody, table, and div
+	if _, err := w.WriteString("</td></tr></tbody></table></div>"); err != nil {
 		return err
 	}
 
@@ -260,12 +304,12 @@ func (c *MJHeroComponent) calculateEffectiveHeight(height, padding string) strin
 	topPadding := paddingVal
 	bottomPadding := paddingVal
 
-	if paddingTopAttr := c.GetAttribute("padding-top"); paddingTopAttr != nil {
+	if paddingTopAttr := c.GetAttribute(constants.MJMLPaddingTop); paddingTopAttr != nil {
 		topPaddingPx := strings.TrimSuffix(*paddingTopAttr, "px")
 		fmt.Sscanf(topPaddingPx, "%d", &topPadding)
 	}
 
-	if paddingBottomAttr := c.GetAttribute("padding-bottom"); paddingBottomAttr != nil {
+	if paddingBottomAttr := c.GetAttribute(constants.MJMLPaddingBottom); paddingBottomAttr != nil {
 		bottomPaddingPx := strings.TrimSuffix(*paddingBottomAttr, "px")
 		fmt.Sscanf(bottomPaddingPx, "%d", &bottomPadding)
 	}
@@ -281,18 +325,18 @@ func (c *MJHeroComponent) calculateEffectiveHeight(height, padding string) strin
 
 func (c *MJHeroComponent) GetDefaultAttribute(name string) string {
 	switch name {
-	case "background-color":
+	case constants.MJMLBackgroundColor:
 		return "#ffffff"
-	case "background-position":
+	case constants.MJMLBackgroundPosition:
 		return "center center"
-	case "height":
+	case constants.MJMLHeight:
 		return "0px"
-	case "mode":
+	case constants.MJMLMode:
 		return "fixed-height"
-	case "padding":
+	case constants.MJMLPadding:
 		return "0px"
-	case "vertical-align":
-		return "top"
+	case constants.MJMLVerticalAlign:
+		return constants.VAlignTop
 	default:
 		return ""
 	}

--- a/mjml/components/hero.go
+++ b/mjml/components/hero.go
@@ -1,8 +1,11 @@
 package components
 
 import (
+	"fmt"
 	"io"
+	"strings"
 
+	"github.com/preslavrachev/gomjml/mjml/html"
 	"github.com/preslavrachev/gomjml/mjml/options"
 	"github.com/preslavrachev/gomjml/parser"
 )
@@ -19,12 +22,261 @@ func NewMJHeroComponent(node *parser.MJMLNode, opts *options.RenderOpts) *MJHero
 }
 
 func (c *MJHeroComponent) Render(w io.StringWriter) error {
-	// TODO: Implement mj-hero component functionality
-	return &NotImplementedError{ComponentName: "mj-hero"}
+	// Helper function to get attribute with default
+	getAttr := func(name string) string {
+		if attr := c.GetAttribute(name); attr != nil {
+			return *attr
+		}
+		return c.GetDefaultAttribute(name)
+	}
+
+	// Get attributes
+	backgroundColor := getAttr("background-color")
+	backgroundPosition := getAttr("background-position")
+	backgroundRepeat := "no-repeat"
+	backgroundUrl := getAttr("background-url")
+	backgroundHeight := getAttr("background-height")
+	height := getAttr("height")
+	padding := getAttr("padding")
+	verticalAlign := getAttr("vertical-align")
+
+	// Calculate effective height by subtracting padding
+	effectiveHeight := height
+	if height != "" && height != "0px" {
+		effectiveHeight = c.calculateEffectiveHeight(height, padding)
+	}
+
+	// Calculate container width - use parent width or default 600px
+	containerWidth := c.GetContainerWidth()
+	if containerWidth == 0 {
+		containerWidth = 600
+	}
+	containerWidthPx := fmt.Sprintf("%dpx", containerWidth)
+
+	// MSO conditional comment for Outlook support
+	if _, err := w.WriteString("<!--[if mso | IE]>"); err != nil {
+		return err
+	}
+
+	// MSO table structure
+	msoTable := fmt.Sprintf(`<table border="0" cellpadding="0" cellspacing="0" role="presentation" align="center" width="%d" style="width:%s;"><tr><td style="line-height:0;font-size:0;mso-line-height-rule:exactly;">`, containerWidth, containerWidthPx)
+	if _, err := w.WriteString(msoTable); err != nil {
+		return err
+	}
+
+	// Add VML image for Outlook if background-url is provided
+	if backgroundUrl != "" {
+		vmlStyle := fmt.Sprintf("border:0;mso-position-horizontal:center;position:absolute;top:0;width:%s;z-index:-3;", containerWidthPx)
+		if backgroundHeight != "" && backgroundHeight != "0px" {
+			vmlStyle = fmt.Sprintf("border:0;height:%s;mso-position-horizontal:center;position:absolute;top:0;width:%s;z-index:-3;", backgroundHeight, containerWidthPx)
+		}
+		vmlImage := fmt.Sprintf(`<v:image src="%s" xmlns:v="urn:schemas-microsoft-com:vml" style="%s" />`, backgroundUrl, vmlStyle)
+		if _, err := w.WriteString(vmlImage); err != nil {
+			return err
+		}
+	} else {
+		vmlImage := fmt.Sprintf(`<v:image xmlns:v="urn:schemas-microsoft-com:vml" style="border:0;mso-position-horizontal:center;position:absolute;top:0;width:%s;z-index:-3;" />`, containerWidthPx)
+		if _, err := w.WriteString(vmlImage); err != nil {
+			return err
+		}
+	}
+
+	if _, err := w.WriteString("<![endif]-->"); err != nil {
+		return err
+	}
+
+	// Main responsive container
+	if _, err := w.WriteString(`<div`); err != nil {
+		return err
+	}
+
+	// Add css-class if present
+	if cssClass := c.BuildClassAttribute(); cssClass != "" {
+		if _, err := w.WriteString(` class="`); err != nil {
+			return err
+		}
+		if _, err := w.WriteString(cssClass); err != nil {
+			return err
+		}
+		if _, err := w.WriteString(`"`); err != nil {
+			return err
+		}
+	}
+
+	if _, err := w.WriteString(` style="margin:0 auto;max-width:`); err != nil {
+		return err
+	}
+	if _, err := w.WriteString(containerWidthPx); err != nil {
+		return err
+	}
+	if _, err := w.WriteString(`;">`); err != nil {
+		return err
+	}
+
+	// Main table
+	if _, err := w.WriteString(`<table border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"><tbody><tr style="vertical-align:top;">`); err != nil {
+		return err
+	}
+
+	// Main TD with background and height using HTMLTag builder
+	tdTag := html.NewHTMLTag("td").
+		AddAttribute("height", strings.TrimSuffix(effectiveHeight, "px")).
+		AddStyle("background", backgroundColor).
+		AddStyle("background-position", backgroundPosition).
+		AddStyle("background-repeat", backgroundRepeat).
+		AddStyle("padding", padding).
+		AddStyle("vertical-align", verticalAlign).
+		AddStyle("height", effectiveHeight)
+
+	// Add background image if provided
+	if backgroundUrl != "" {
+		tdTag.AddAttribute("background", backgroundUrl)
+		// Add CSS shorthand background for modern email clients
+		shorthandBg := fmt.Sprintf("%s url('%s') %s %s / cover", backgroundColor, backgroundUrl, backgroundRepeat, backgroundPosition)
+		tdTag.AddStyle("background", shorthandBg)
+	}
+
+	// Add individual padding overrides (similar to other components)
+	if paddingTopAttr := c.GetAttribute("padding-top"); paddingTopAttr != nil {
+		tdTag.AddStyle("padding-top", *paddingTopAttr)
+	}
+	if paddingRightAttr := c.GetAttribute("padding-right"); paddingRightAttr != nil {
+		tdTag.AddStyle("padding-right", *paddingRightAttr)
+	}
+	if paddingBottomAttr := c.GetAttribute("padding-bottom"); paddingBottomAttr != nil {
+		tdTag.AddStyle("padding-bottom", *paddingBottomAttr)
+	}
+	if paddingLeftAttr := c.GetAttribute("padding-left"); paddingLeftAttr != nil {
+		tdTag.AddStyle("padding-left", *paddingLeftAttr)
+	}
+
+	if err := tdTag.RenderOpen(w); err != nil {
+		return err
+	}
+
+	// MSO inner table
+	if _, err := w.WriteString("<!--[if mso | IE]>"); err != nil {
+		return err
+	}
+
+	msoInnerTable := fmt.Sprintf(`<table border="0" cellpadding="0" cellspacing="0" width="%d" style="width:%s;"><tr><td><![endif]-->`, containerWidth, containerWidthPx)
+	if _, err := w.WriteString(msoInnerTable); err != nil {
+		return err
+	}
+
+	// Hero content container
+	if _, err := w.WriteString(`<div class="mj-hero-content" style="margin:0px auto;">`); err != nil {
+		return err
+	}
+
+	// Content table structure
+	if _, err := w.WriteString(`<table border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;margin:0px;"><tbody><tr><td>`); err != nil {
+		return err
+	}
+
+	// Inner content table for children
+	if _, err := w.WriteString(`<table border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;margin:0px;"><tbody>`); err != nil {
+		return err
+	}
+
+	// Render child components
+	for _, child := range c.Children {
+		// Set container width for children
+		child.SetContainerWidth(containerWidth)
+
+		// Set hero context for child rendering
+		childOpts := *c.RenderOpts // Copy the options
+		childOpts.InsideHero = true
+
+		// Set render options based on component type
+		switch comp := child.(type) {
+		case *MJTextComponent:
+			comp.RenderOpts = &childOpts
+		case *MJButtonComponent:
+			comp.RenderOpts = &childOpts
+		case *MJImageComponent:
+			comp.RenderOpts = &childOpts
+			// Add more component types as needed
+		}
+
+		if err := child.Render(w); err != nil {
+			return err
+		}
+	}
+
+	// Close inner content table
+	if _, err := w.WriteString(`</tbody></table>`); err != nil {
+		return err
+	}
+
+	// Close content structure
+	if _, err := w.WriteString(`</td></tr></tbody></table></div>`); err != nil {
+		return err
+	}
+
+	// Close MSO inner table
+	if _, err := w.WriteString("<!--[if mso | IE]></td></tr></table><![endif]-->"); err != nil {
+		return err
+	}
+
+	// Close main TD and table
+	if _, err := w.WriteString(`</td></tr></tbody></table></div>`); err != nil {
+		return err
+	}
+
+	// Close MSO main table
+	if _, err := w.WriteString("<!--[if mso | IE]></td></tr></table><![endif]-->"); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (c *MJHeroComponent) GetTagName() string {
 	return "mj-hero"
+}
+
+// calculateEffectiveHeight calculates the effective height by subtracting top and bottom padding
+func (c *MJHeroComponent) calculateEffectiveHeight(height, padding string) string {
+	if height == "" || height == "0px" {
+		return height
+	}
+
+	// Parse height value
+	heightPx := strings.TrimSuffix(height, "px")
+	heightVal := 0
+	if _, err := fmt.Sscanf(heightPx, "%d", &heightVal); err != nil {
+		return height // Return original if parsing fails
+	}
+
+	// Parse padding value
+	paddingPx := strings.TrimSuffix(padding, "px")
+	paddingVal := 0
+	if paddingPx != "" && paddingPx != "0" {
+		fmt.Sscanf(paddingPx, "%d", &paddingVal)
+	}
+
+	// Get individual padding overrides
+	topPadding := paddingVal
+	bottomPadding := paddingVal
+
+	if paddingTopAttr := c.GetAttribute("padding-top"); paddingTopAttr != nil {
+		topPaddingPx := strings.TrimSuffix(*paddingTopAttr, "px")
+		fmt.Sscanf(topPaddingPx, "%d", &topPadding)
+	}
+
+	if paddingBottomAttr := c.GetAttribute("padding-bottom"); paddingBottomAttr != nil {
+		bottomPaddingPx := strings.TrimSuffix(*paddingBottomAttr, "px")
+		fmt.Sscanf(bottomPaddingPx, "%d", &bottomPadding)
+	}
+
+	// Calculate effective height = original height - top padding - bottom padding
+	effectiveHeightVal := heightVal - topPadding - bottomPadding
+	if effectiveHeightVal < 0 {
+		effectiveHeightVal = 0
+	}
+
+	return fmt.Sprintf("%dpx", effectiveHeightVal)
 }
 
 func (c *MJHeroComponent) GetDefaultAttribute(name string) string {

--- a/mjml/components/hero.go
+++ b/mjml/components/hero.go
@@ -136,7 +136,7 @@ func (c *MJHeroComponent) Render(w io.StringWriter) error {
 
 	// Add background image if provided
 	if backgroundUrl != "" {
-		tdTag.AddAttribute(constants.CSSBackground, backgroundUrl)
+		tdTag.AddAttribute(constants.AttrBackground, backgroundUrl)
 		// Add CSS shorthand background for modern email clients
 		shorthandBg := fmt.Sprintf("%s url('%s') %s %s / cover", backgroundColor, backgroundUrl, backgroundRepeat, backgroundPosition)
 		tdTag.AddStyle(constants.CSSBackground, shorthandBg)
@@ -297,7 +297,9 @@ func (c *MJHeroComponent) calculateEffectiveHeight(height, padding string) strin
 	paddingPx := strings.TrimSuffix(padding, "px")
 	paddingVal := 0
 	if paddingPx != "" && paddingPx != "0" {
-		fmt.Sscanf(paddingPx, "%d", &paddingVal)
+		if _, err := fmt.Sscanf(paddingPx, "%d", &paddingVal); err != nil {
+			paddingVal = 0 // Default to 0 if parsing fails
+		}
 	}
 
 	// Get individual padding overrides
@@ -306,12 +308,16 @@ func (c *MJHeroComponent) calculateEffectiveHeight(height, padding string) strin
 
 	if paddingTopAttr := c.GetAttribute(constants.MJMLPaddingTop); paddingTopAttr != nil {
 		topPaddingPx := strings.TrimSuffix(*paddingTopAttr, "px")
-		fmt.Sscanf(topPaddingPx, "%d", &topPadding)
+		if _, err := fmt.Sscanf(topPaddingPx, "%d", &topPadding); err != nil {
+			topPadding = paddingVal // Fallback to general padding if parsing fails
+		}
 	}
 
 	if paddingBottomAttr := c.GetAttribute(constants.MJMLPaddingBottom); paddingBottomAttr != nil {
 		bottomPaddingPx := strings.TrimSuffix(*paddingBottomAttr, "px")
-		fmt.Sscanf(bottomPaddingPx, "%d", &bottomPadding)
+		if _, err := fmt.Sscanf(bottomPaddingPx, "%d", &bottomPadding); err != nil {
+			bottomPadding = paddingVal // Fallback to general padding if parsing fails
+		}
 	}
 
 	// Calculate effective height = original height - top padding - bottom padding

--- a/mjml/components/navbar.go
+++ b/mjml/components/navbar.go
@@ -153,7 +153,7 @@ func (c *MJNavbarComponent) renderHamburgerLabel(w io.StringWriter, checkboxID s
 
 	labelTag := html.NewHTMLTag("label").
 		AddAttribute(constants.AttrAlign, icoAlign).
-		AddAttribute("for", checkboxID).
+		AddAttribute(constants.AttrFor, checkboxID).
 		AddAttribute(constants.AttrClass, "mj-menu-label").
 		AddStyle(constants.CSSDisplay, constants.DisplayBlock).
 		AddStyle("cursor", "pointer").

--- a/mjml/components/section.go
+++ b/mjml/components/section.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/preslavrachev/gomjml/mjml/constants"
 	"github.com/preslavrachev/gomjml/mjml/html"
 	"github.com/preslavrachev/gomjml/mjml/options"
 	"github.com/preslavrachev/gomjml/parser"
@@ -65,7 +66,7 @@ func (c *MJSectionComponent) Render(w io.StringWriter) error {
 
 	// Add attributes in MRML order: bgcolor, align, width
 	if backgroundColor != "" {
-		msoTable.AddAttribute("bgcolor", backgroundColor)
+		msoTable.AddAttribute(constants.AttrBgcolor, backgroundColor)
 	}
 
 	msoTable.AddAttribute("align", "center").

--- a/mjml/components/wrapper.go
+++ b/mjml/components/wrapper.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/preslavrachev/gomjml/mjml/constants"
 	"github.com/preslavrachev/gomjml/mjml/html"
 	"github.com/preslavrachev/gomjml/mjml/options"
 	"github.com/preslavrachev/gomjml/parser"
@@ -123,7 +124,7 @@ func (c *MJWrapperComponent) renderFullWidthToWriter(w io.StringWriter) error {
 
 	// Add bgcolor to MSO table if background-color is set
 	if bgColor := c.getAttribute("background-color"); bgColor != "" {
-		msoTable.AddAttribute("bgcolor", bgColor)
+		msoTable.AddAttribute(constants.AttrBgcolor, bgColor)
 	}
 
 	msoTable.AddAttribute("align", "center").
@@ -257,7 +258,7 @@ func (c *MJWrapperComponent) renderSimpleToWriter(w io.StringWriter) error {
 
 	// Add bgcolor to MSO table if background-color is set
 	if bgColor := c.getAttribute("background-color"); bgColor != "" {
-		msoTable.AddAttribute("bgcolor", bgColor)
+		msoTable.AddAttribute(constants.AttrBgcolor, bgColor)
 	}
 
 	msoTable.AddAttribute("align", "center").

--- a/mjml/constants/css.go
+++ b/mjml/constants/css.go
@@ -134,6 +134,8 @@ const (
 	MJMLBackgroundSize     = "background-size"
 	MJMLBackgroundPosition = "background-position"
 	MJMLBackgroundRepeat   = "background-repeat"
+	MJMLBackgroundUrl      = "background-url"
+	MJMLBackgroundHeight   = "background-height"
 
 	// Border attributes
 	MJMLBorder       = "border"

--- a/mjml/constants/html.go
+++ b/mjml/constants/html.go
@@ -1,0 +1,28 @@
+package constants
+
+// Additional HTML Attributes - attributes not already defined in css.go
+const (
+	// Email-specific table attributes
+	AttrBackground    = "background"
+	AttrBgcolor       = "bgcolor"
+	AttrVerticalAlign = "vertical-align"
+
+	// Image attributes
+	AttrUsemap = "usemap"
+	AttrIsmap  = "ismap"
+
+	// Form attributes
+	AttrFor      = "for"
+	AttrChecked  = "checked"
+	AttrDisabled = "disabled"
+
+	// Accessibility attributes
+	AttrAriaLabel  = "aria-label"
+	AttrAriaHidden = "aria-hidden"
+	AttrTabindex   = "tabindex"
+
+	// XML/Namespace attributes (for Outlook VML)
+	AttrXmlns  = "xmlns"
+	AttrXmlnsV = "xmlns:v"
+	AttrXmlnsO = "xmlns:o"
+)

--- a/mjml/integration_test.go
+++ b/mjml/integration_test.go
@@ -99,6 +99,17 @@ func TestMJMLAgainstExpected(t *testing.T) {
 		{"mj-navbar-ico", "testdata/mj-navbar-ico.mjml"},
 		{"mj-navbar-align-class", "testdata/mj-navbar-align-class.mjml"},
 		{"mj-navbar-multiple", "testdata/mj-navbar-multiple.mjml"},
+		// MJ-HERO tests
+		{"mj-hero", "testdata/mj-hero.mjml"},
+		{"mj-hero-background-color", "testdata/mj-hero-background-color.mjml"},
+		{"mj-hero-background-height", "testdata/mj-hero-background-height.mjml"},
+		{"mj-hero-background-position", "testdata/mj-hero-background-position.mjml"},
+		{"mj-hero-background-url", "testdata/mj-hero-background-url.mjml"},
+		{"mj-hero-background-width", "testdata/mj-hero-background-width.mjml"},
+		{"mj-hero-class", "testdata/mj-hero-class.mjml"},
+		{"mj-hero-height", "testdata/mj-hero-height.mjml"},
+		{"mj-hero-mode", "testdata/mj-hero-mode.mjml"},
+		{"mj-hero-vertical-align", "testdata/mj-hero-vertical-align.mjml"},
 	}
 
 	for _, tc := range testCases {

--- a/mjml/options/options.go
+++ b/mjml/options/options.go
@@ -43,5 +43,6 @@ func (ft *FontTracker) GetFonts() []string {
 type RenderOpts struct {
 	DebugTags   bool         // Whether to include debug attributes in output
 	InsideGroup bool         // Whether the component is being rendered inside a group
+	InsideHero  bool         // Whether the component is being rendered inside a hero
 	FontTracker *FontTracker // Tracks fonts used during rendering
 }


### PR DESCRIPTION
## Pull Request Overview

This PR adds support for the `mj-hero` component to the MJML library, implementing a hero section component that can display background images and contain child components.

- Implements the complete `mj-hero` component with support for background images, positioning, and child content
- Adds context awareness for child components when rendered inside a hero
- Includes comprehensive test coverage with 9 different hero component scenarios