### PR TITLE
Add support for mj-spacer component

### DIFF
--- a/mjml/components/spacer.go
+++ b/mjml/components/spacer.go
@@ -3,6 +3,8 @@ package components
 import (
 	"io"
 
+	"github.com/preslavrachev/gomjml/mjml/constants"
+	"github.com/preslavrachev/gomjml/mjml/html"
 	"github.com/preslavrachev/gomjml/mjml/options"
 	"github.com/preslavrachev/gomjml/parser"
 )
@@ -19,8 +21,89 @@ func NewMJSpacerComponent(node *parser.MJMLNode, opts *options.RenderOpts) *MJSp
 }
 
 func (c *MJSpacerComponent) Render(w io.StringWriter) error {
-	// TODO: Implement mj-spacer component functionality
-	return &NotImplementedError{ComponentName: "mj-spacer"}
+	height := c.GetAttributeWithDefault(c, constants.MJMLHeight)
+	containerBackgroundColor := c.GetAttributeWithDefault(c, constants.MJMLContainerBackgroundColor)
+	padding := c.GetAttributeWithDefault(c, constants.MJMLPadding)
+	paddingTop := c.GetAttributeWithDefault(c, constants.MJMLPaddingTop)
+	paddingRight := c.GetAttributeWithDefault(c, constants.MJMLPaddingRight)
+	paddingBottom := c.GetAttributeWithDefault(c, constants.MJMLPaddingBottom)
+	paddingLeft := c.GetAttributeWithDefault(c, constants.MJMLPaddingLeft)
+	verticalAlign := c.GetAttributeWithDefault(c, constants.MJMLVerticalAlign)
+
+	// Create table row
+	if _, err := w.WriteString("<tr>"); err != nil {
+		return err
+	}
+
+	// Create table cell with base styles
+	td := html.NewHTMLTag("td").
+		AddStyle(constants.CSSFontSize, "0px").
+		AddStyle(constants.CSSWordBreak, "break-word")
+
+	// Add optional styles
+	if containerBackgroundColor != "" {
+		td.AddStyle(constants.CSSBackground, containerBackgroundColor)
+	}
+
+	if classAttr := c.BuildClassAttribute(); classAttr != "" {
+		td.AddAttribute(constants.AttrClass, classAttr)
+	}
+
+	// Handle padding attributes
+	if padding != "" {
+		td.AddStyle(constants.CSSPadding, padding)
+	}
+	if paddingTop != "" {
+		td.AddStyle(constants.CSSPaddingTop, paddingTop)
+	}
+	if paddingRight != "" {
+		td.AddStyle(constants.CSSPaddingRight, paddingRight)
+	}
+	if paddingBottom != "" {
+		td.AddStyle(constants.CSSPaddingBottom, paddingBottom)
+	}
+	if paddingLeft != "" {
+		td.AddStyle(constants.CSSPaddingLeft, paddingLeft)
+	}
+
+	// Add vertical-align as attribute (not style) if specified
+	if verticalAlign != "" {
+		td.AddAttribute(constants.AttrVerticalAlign, verticalAlign)
+	}
+
+	// Render table cell opening tag
+	if err := td.RenderOpen(w); err != nil {
+		return err
+	}
+
+	// Create div with height and line-height, containing thin space character
+	div := html.NewHTMLTag("div").
+		AddStyle(constants.CSSHeight, height).
+		AddStyle(constants.CSSLineHeight, height)
+
+	if err := div.RenderOpen(w); err != nil {
+		return err
+	}
+
+	// Add thin space character (&#8202;)
+	if _, err := w.WriteString("&#8202;"); err != nil {
+		return err
+	}
+
+	if err := div.RenderClose(w); err != nil {
+		return err
+	}
+
+	// Close table cell and row
+	if err := td.RenderClose(w); err != nil {
+		return err
+	}
+
+	if _, err := w.WriteString("</tr>"); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (c *MJSpacerComponent) GetTagName() string {
@@ -29,7 +112,7 @@ func (c *MJSpacerComponent) GetTagName() string {
 
 func (c *MJSpacerComponent) GetDefaultAttribute(name string) string {
 	switch name {
-	case "height":
+	case constants.MJMLHeight:
 		return "20px"
 	default:
 		return ""

--- a/mjml/components/spacer.go
+++ b/mjml/components/spacer.go
@@ -86,6 +86,8 @@ func (c *MJSpacerComponent) Render(w io.StringWriter) error {
 	}
 
 	// Add thin space character (&#8202;)
+	// The thin space character is used here to ensure the spacer div renders with the correct height in email clients.
+	// Some clients ignore empty divs or collapse whitespace, and using &nbsp; or a regular space may result in unwanted extra height or layout issues.
 	if _, err := w.WriteString("&#8202;"); err != nil {
 		return err
 	}

--- a/mjml/constants/css.go
+++ b/mjml/constants/css.go
@@ -35,6 +35,7 @@ const (
 	CSSTextTransform  = "text-transform"
 	CSSLetterSpacing  = "letter-spacing"
 	CSSWordSpacing    = "word-spacing"
+	CSSWordBreak      = "word-break"
 	CSSColor          = "color"
 
 	// Background & Visual

--- a/mjml/integration_test.go
+++ b/mjml/integration_test.go
@@ -110,6 +110,8 @@ func TestMJMLAgainstExpected(t *testing.T) {
 		{"mj-hero-height", "testdata/mj-hero-height.mjml"},
 		{"mj-hero-mode", "testdata/mj-hero-mode.mjml"},
 		{"mj-hero-vertical-align", "testdata/mj-hero-vertical-align.mjml"},
+		// MJ-SPACER test
+		{"mj-spacer", "testdata/mj-spacer.mjml"},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This PR implements support for the mj-spacer component in the MJML rendering library. The mj-spacer component creates vertical spacing between other elements in email templates.

- Complete implementation of the MJSpacerComponent's Render method with proper HTML table structure
- Addition of necessary CSS constants and integration test coverage
- Replacement of placeholder implementation with full functionality