### PR TITLE
Add support for mj-table

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,11 +252,11 @@ func (c *MJNewComponent) GetTagName() string {
 | `mj-carousel-image` | ❌ **Not Implemented** | Images within carousel |
 | `mj-hero` | ✅ **Implemented** | Header/banner sections with background images |
 | `mj-spacer` | ✅ **Implemented** | Layout spacing control |
-| `mj-table` | ❌ **Not Implemented** | Email-safe table component |
+| `mj-table` | ✅ **Implemented** | Email-safe table component with border and styling support |
 
 ### Implementation Summary
-- **✅ Implemented: 23 components** - All essential layout, content, head components, accordion, navbar, hero, and spacer work
-- **❌ Not Implemented: 3 components** - Advanced interactive components return `NotImplementedError`
+- **✅ Implemented: 24 components** - All essential layout, content, head components, accordion, navbar, hero, spacer, and table work
+- **❌ Not Implemented: 2 components** - Advanced interactive components return `NotImplementedError`
 - **Total MJML Components: 26** - Covers all major MJML specification components
 
 ### Integration Test Status

--- a/mjml/components/column.go
+++ b/mjml/components/column.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/preslavrachev/gomjml/mjml/constants"
 	"github.com/preslavrachev/gomjml/mjml/html"
 	"github.com/preslavrachev/gomjml/mjml/options"
 	"github.com/preslavrachev/gomjml/mjml/styles"
@@ -276,7 +277,7 @@ func (c *MJColumnComponent) GetMSOTDStyles() map[string]string {
 
 // hasGutter checks if the column has any padding attributes
 func (c *MJColumnComponent) hasGutter() bool {
-	paddingAttrs := []string{"padding", "padding-top", "padding-right", "padding-bottom", "padding-left"}
+	paddingAttrs := []string{constants.MJMLPadding, constants.MJMLPaddingTop, constants.MJMLPaddingRight, constants.MJMLPaddingBottom, constants.MJMLPaddingLeft}
 	for _, attr := range paddingAttrs {
 		if c.GetAttribute(attr) != nil {
 			return true
@@ -314,17 +315,17 @@ func (c *MJColumnComponent) renderGutter(w io.StringWriter) error {
 	if padding := c.GetAttribute("padding"); padding != nil {
 		gutterTd.AddStyle("padding", *padding)
 	}
-	if paddingTop := c.GetAttribute("padding-top"); paddingTop != nil {
-		gutterTd.AddStyle("padding-top", *paddingTop)
+	if paddingTop := c.GetAttribute(constants.MJMLPaddingTop); paddingTop != nil {
+		gutterTd.AddStyle(constants.CSSPaddingTop, *paddingTop)
 	}
-	if paddingRight := c.GetAttribute("padding-right"); paddingRight != nil {
-		gutterTd.AddStyle("padding-right", *paddingRight)
+	if paddingRight := c.GetAttribute(constants.MJMLPaddingRight); paddingRight != nil {
+		gutterTd.AddStyle(constants.CSSPaddingRight, *paddingRight)
 	}
-	if paddingBottom := c.GetAttribute("padding-bottom"); paddingBottom != nil {
-		gutterTd.AddStyle("padding-bottom", *paddingBottom)
+	if paddingBottom := c.GetAttribute(constants.MJMLPaddingBottom); paddingBottom != nil {
+		gutterTd.AddStyle(constants.CSSPaddingBottom, *paddingBottom)
 	}
-	if paddingLeft := c.GetAttribute("padding-left"); paddingLeft != nil {
-		gutterTd.AddStyle("padding-left", *paddingLeft)
+	if paddingLeft := c.GetAttribute(constants.MJMLPaddingLeft); paddingLeft != nil {
+		gutterTd.AddStyle(constants.CSSPaddingLeft, *paddingLeft)
 	}
 
 	if err := gutterTd.RenderOpen(w); err != nil {

--- a/mjml/components/section.go
+++ b/mjml/components/section.go
@@ -137,17 +137,17 @@ func (c *MJSectionComponent) Render(w io.StringWriter) error {
 		AddStyle("padding", padding)
 
 	// Add specific padding overrides in MRML order: left, right, top, bottom
-	if paddingLeftAttr := c.GetAttribute("padding-left"); paddingLeftAttr != nil {
-		tdTag.AddStyle("padding-left", *paddingLeftAttr)
+	if paddingLeftAttr := c.GetAttribute(constants.MJMLPaddingLeft); paddingLeftAttr != nil {
+		tdTag.AddStyle(constants.CSSPaddingLeft, *paddingLeftAttr)
 	}
-	if paddingRightAttr := c.GetAttribute("padding-right"); paddingRightAttr != nil {
-		tdTag.AddStyle("padding-right", *paddingRightAttr)
+	if paddingRightAttr := c.GetAttribute(constants.MJMLPaddingRight); paddingRightAttr != nil {
+		tdTag.AddStyle(constants.CSSPaddingRight, *paddingRightAttr)
 	}
-	if paddingTopAttr := c.GetAttribute("padding-top"); paddingTopAttr != nil {
-		tdTag.AddStyle("padding-top", *paddingTopAttr)
+	if paddingTopAttr := c.GetAttribute(constants.MJMLPaddingTop); paddingTopAttr != nil {
+		tdTag.AddStyle(constants.CSSPaddingTop, *paddingTopAttr)
 	}
-	if paddingBottomAttr := c.GetAttribute("padding-bottom"); paddingBottomAttr != nil {
-		tdTag.AddStyle("padding-bottom", *paddingBottomAttr)
+	if paddingBottomAttr := c.GetAttribute(constants.MJMLPaddingBottom); paddingBottomAttr != nil {
+		tdTag.AddStyle(constants.CSSPaddingBottom, *paddingBottomAttr)
 	}
 
 	tdTag.AddStyle("text-align", textAlign)

--- a/mjml/components/table.go
+++ b/mjml/components/table.go
@@ -2,8 +2,11 @@ package components
 
 import (
 	"io"
+	"strings"
 
+	"github.com/preslavrachev/gomjml/mjml/constants"
 	"github.com/preslavrachev/gomjml/mjml/fonts"
+	"github.com/preslavrachev/gomjml/mjml/html"
 	"github.com/preslavrachev/gomjml/mjml/options"
 	"github.com/preslavrachev/gomjml/parser"
 )
@@ -20,8 +23,92 @@ func NewMJTableComponent(node *parser.MJMLNode, opts *options.RenderOpts) *MJTab
 }
 
 func (c *MJTableComponent) Render(w io.StringWriter) error {
-	// TODO: Implement mj-table component functionality
-	return &NotImplementedError{ComponentName: "mj-table"}
+	// Get attributes
+	align := c.GetAttributeWithDefault(c, constants.MJMLAlign)
+	padding := c.GetAttributeWithDefault(c, constants.MJMLPadding)
+
+	// Create TR element
+	if _, err := w.WriteString("<tr>"); err != nil {
+		return err
+	}
+
+	// Create TD with alignment and base styles
+	tdTag := html.NewHTMLTag("td").
+		AddAttribute(constants.AttrAlign, align).
+		AddStyle(constants.CSSFontSize, "0px").
+		AddStyle(constants.CSSPadding, padding).
+		AddStyle(constants.CSSWordBreak, "break-word")
+
+	// Add container background color if specified
+	if bgColor := c.GetAttribute(constants.MJMLContainerBackgroundColor); bgColor != nil {
+		tdTag.AddStyle(constants.CSSBackground, *bgColor)
+	}
+
+	// Add css-class if present
+	if cssClass := c.BuildClassAttribute(); cssClass != "" {
+		tdTag.AddAttribute(constants.AttrClass, cssClass)
+	}
+
+	// Add specific padding overrides if they exist
+	if paddingTop := c.GetAttribute("padding-top"); paddingTop != nil {
+		tdTag.AddStyle(constants.CSSPaddingTop, *paddingTop)
+	}
+	if paddingBottom := c.GetAttribute("padding-bottom"); paddingBottom != nil {
+		tdTag.AddStyle(constants.CSSPaddingBottom, *paddingBottom)
+	}
+	if paddingLeft := c.GetAttribute("padding-left"); paddingLeft != nil {
+		tdTag.AddStyle(constants.CSSPaddingLeft, *paddingLeft)
+	}
+	if paddingRight := c.GetAttribute("padding-right"); paddingRight != nil {
+		tdTag.AddStyle(constants.CSSPaddingRight, *paddingRight)
+	}
+
+	if err := tdTag.RenderOpen(w); err != nil {
+		return err
+	}
+
+	// Create table element with styles
+	borderValue := c.GetAttributeWithDefault(c, constants.MJMLBorder)
+	htmlBorderValue := "0" // HTML border attribute should always be "0"
+	if borderValue != "none" {
+		htmlBorderValue = "0" // Even with CSS border, HTML border should be "0"
+	}
+
+	tableTag := html.NewHTMLTag("table").
+		AddAttribute(constants.AttrBorder, htmlBorderValue).
+		AddAttribute(constants.AttrCellPadding, c.GetAttributeWithDefault(c, "cellpadding")).
+		AddAttribute(constants.AttrCellSpacing, c.GetAttributeWithDefault(c, "cellspacing")).
+		AddAttribute(constants.AttrWidth, c.GetAttributeWithDefault(c, constants.MJMLWidth)).
+		AddStyle(constants.CSSColor, c.GetAttributeWithDefault(c, constants.MJMLColor)).
+		AddStyle(constants.CSSFontFamily, c.GetAttributeWithDefault(c, constants.MJMLFontFamily)).
+		AddStyle(constants.CSSFontSize, c.GetAttributeWithDefault(c, constants.MJMLFontSize)).
+		AddStyle(constants.CSSLineHeight, c.GetAttributeWithDefault(c, constants.MJMLLineHeight)).
+		AddStyle(constants.CSSTableLayout, c.GetAttributeWithDefault(c, "table-layout")).
+		AddStyle(constants.CSSWidth, c.GetAttributeWithDefault(c, constants.MJMLWidth)).
+		AddStyle(constants.CSSBorder, borderValue) // Use the actual border value for CSS
+
+	if err := tableTag.RenderOpen(w); err != nil {
+		return err
+	}
+
+	// Write the inner HTML content (TR, TH, TD elements)
+	if err := c.writeInnerTableContent(w); err != nil {
+		return err
+	}
+
+	if err := tableTag.RenderClose(w); err != nil {
+		return err
+	}
+
+	if err := tdTag.RenderClose(w); err != nil {
+		return err
+	}
+
+	if _, err := w.WriteString("</tr>"); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (c *MJTableComponent) GetTagName() string {
@@ -32,7 +119,7 @@ func (c *MJTableComponent) GetDefaultAttribute(name string) string {
 	switch name {
 	case "align":
 		return "left"
-	case "border":
+	case constants.MJMLBorder:
 		return "none"
 	case "cellpadding":
 		return "0"
@@ -55,4 +142,97 @@ func (c *MJTableComponent) GetDefaultAttribute(name string) string {
 	default:
 		return ""
 	}
+}
+
+// writeInnerTableContent writes the inner HTML content (TR, TH, TD elements) to the writer
+func (c *MJTableComponent) writeInnerTableContent(w io.StringWriter) error {
+	// If we have children (HTML elements), we need to reconstruct the original HTML
+	if len(c.Node.Children) > 0 {
+		// Add children as HTML elements (skip text content to avoid extra whitespace)
+		for _, child := range c.Node.Children {
+			if err := c.reconstructHTMLElement(child, w); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	// If no children, write the text content with whitespace trimmed
+	if c.Node.Text != "" {
+		_, err := w.WriteString(strings.TrimSpace(c.Node.Text))
+		return err
+	}
+
+	return nil
+}
+
+// reconstructHTMLElement reconstructs an HTML element from a parsed node
+func (c *MJTableComponent) reconstructHTMLElement(node *parser.MJMLNode, w io.StringWriter) error {
+	tagName := node.XMLName.Local
+
+	// Check if this is a void element (self-closing)
+	isVoidElement := isVoidHTMLElement(tagName)
+
+	// Opening tag
+	if _, err := w.WriteString("<"); err != nil {
+		return err
+	}
+	if _, err := w.WriteString(tagName); err != nil {
+		return err
+	}
+
+	// Attributes
+	for _, attr := range node.Attrs {
+		if _, err := w.WriteString(" "); err != nil {
+			return err
+		}
+		if _, err := w.WriteString(attr.Name.Local); err != nil {
+			return err
+		}
+		if _, err := w.WriteString(`="`); err != nil {
+			return err
+		}
+		if _, err := w.WriteString(attr.Value); err != nil {
+			return err
+		}
+		if _, err := w.WriteString(`"`); err != nil {
+			return err
+		}
+	}
+
+	if isVoidElement {
+		// Self-closing tag
+		_, err := w.WriteString(" />")
+		return err
+	}
+
+	if _, err := w.WriteString(">"); err != nil {
+		return err
+	}
+
+	// Content (text + children) - trim whitespace to match MRML behavior
+	if node.Text != "" {
+		trimmedText := strings.TrimSpace(node.Text)
+		if trimmedText != "" {
+			if _, err := w.WriteString(trimmedText); err != nil {
+				return err
+			}
+		}
+	}
+
+	for _, child := range node.Children {
+		if err := c.reconstructHTMLElement(child, w); err != nil {
+			return err
+		}
+	}
+
+	// Closing tag
+	if _, err := w.WriteString("</"); err != nil {
+		return err
+	}
+	if _, err := w.WriteString(tagName); err != nil {
+		return err
+	}
+	_, err := w.WriteString(">")
+	return err
 }

--- a/mjml/components/table.go
+++ b/mjml/components/table.go
@@ -50,16 +50,16 @@ func (c *MJTableComponent) Render(w io.StringWriter) error {
 	}
 
 	// Add specific padding overrides if they exist
-	if paddingTop := c.GetAttribute("padding-top"); paddingTop != nil {
+	if paddingTop := c.GetAttribute(constants.MJMLPaddingTop); paddingTop != nil {
 		tdTag.AddStyle(constants.CSSPaddingTop, *paddingTop)
 	}
-	if paddingBottom := c.GetAttribute("padding-bottom"); paddingBottom != nil {
+	if paddingBottom := c.GetAttribute(constants.MJMLPaddingBottom); paddingBottom != nil {
 		tdTag.AddStyle(constants.CSSPaddingBottom, *paddingBottom)
 	}
-	if paddingLeft := c.GetAttribute("padding-left"); paddingLeft != nil {
+	if paddingLeft := c.GetAttribute(constants.MJMLPaddingLeft); paddingLeft != nil {
 		tdTag.AddStyle(constants.CSSPaddingLeft, *paddingLeft)
 	}
-	if paddingRight := c.GetAttribute("padding-right"); paddingRight != nil {
+	if paddingRight := c.GetAttribute(constants.MJMLPaddingRight); paddingRight != nil {
 		tdTag.AddStyle(constants.CSSPaddingRight, *paddingRight)
 	}
 

--- a/mjml/components/text.go
+++ b/mjml/components/text.go
@@ -65,17 +65,17 @@ func (c *MJTextComponent) Render(w io.StringWriter) error {
 	}
 
 	// Add specific padding overrides if they exist (following MRML/section pattern)
-	if paddingTopAttr := c.GetAttribute("padding-top"); paddingTopAttr != nil {
-		tdTag.AddStyle("padding-top", *paddingTopAttr)
+	if paddingTopAttr := c.GetAttribute(constants.MJMLPaddingTop); paddingTopAttr != nil {
+		tdTag.AddStyle(constants.CSSPaddingTop, *paddingTopAttr)
 	}
-	if paddingBottomAttr := c.GetAttribute("padding-bottom"); paddingBottomAttr != nil {
-		tdTag.AddStyle("padding-bottom", *paddingBottomAttr)
+	if paddingBottomAttr := c.GetAttribute(constants.MJMLPaddingBottom); paddingBottomAttr != nil {
+		tdTag.AddStyle(constants.CSSPaddingBottom, *paddingBottomAttr)
 	}
-	if paddingLeftAttr := c.GetAttribute("padding-left"); paddingLeftAttr != nil {
-		tdTag.AddStyle("padding-left", *paddingLeftAttr)
+	if paddingLeftAttr := c.GetAttribute(constants.MJMLPaddingLeft); paddingLeftAttr != nil {
+		tdTag.AddStyle(constants.CSSPaddingLeft, *paddingLeftAttr)
 	}
-	if paddingRightAttr := c.GetAttribute("padding-right"); paddingRightAttr != nil {
-		tdTag.AddStyle("padding-right", *paddingRightAttr)
+	if paddingRightAttr := c.GetAttribute(constants.MJMLPaddingRight); paddingRightAttr != nil {
+		tdTag.AddStyle(constants.CSSPaddingRight, *paddingRightAttr)
 	}
 
 	tdTag.AddStyle("word-break", "break-word")

--- a/mjml/components/wrapper.go
+++ b/mjml/components/wrapper.go
@@ -182,11 +182,11 @@ func (c *MJWrapperComponent) renderFullWidthToWriter(w io.StringWriter) error {
 		AddStyle("padding", padding)
 
 	// Add individual padding properties after shorthand to match MRML order (bottom first, then top)
-	if paddingBottom := c.getAttribute("padding-bottom"); paddingBottom != "" {
-		innerTd.AddStyle("padding-bottom", paddingBottom)
+	if paddingBottom := c.getAttribute(constants.MJMLPaddingBottom); paddingBottom != "" {
+		innerTd.AddStyle(constants.CSSPaddingBottom, paddingBottom)
 	}
-	if paddingTop := c.getAttribute("padding-top"); paddingTop != "" {
-		innerTd.AddStyle("padding-top", paddingTop)
+	if paddingTop := c.getAttribute(constants.MJMLPaddingTop); paddingTop != "" {
+		innerTd.AddStyle(constants.CSSPaddingTop, paddingTop)
 	}
 
 	innerTd.AddStyle("text-align", textAlign)
@@ -342,11 +342,11 @@ func (c *MJWrapperComponent) renderSimpleToWriter(w io.StringWriter) error {
 		AddStyle("padding", padding)
 
 	// Add individual padding properties after shorthand to match MRML order (bottom first, then top)
-	if paddingBottom := c.getAttribute("padding-bottom"); paddingBottom != "" {
-		mainTd.AddStyle("padding-bottom", paddingBottom)
+	if paddingBottom := c.getAttribute(constants.MJMLPaddingBottom); paddingBottom != "" {
+		mainTd.AddStyle(constants.CSSPaddingBottom, paddingBottom)
 	}
-	if paddingTop := c.getAttribute("padding-top"); paddingTop != "" {
-		mainTd.AddStyle("padding-top", paddingTop)
+	if paddingTop := c.getAttribute(constants.MJMLPaddingTop); paddingTop != "" {
+		mainTd.AddStyle(constants.CSSPaddingTop, paddingTop)
 	}
 
 	mainTd.AddStyle("text-align", textAlign)

--- a/mjml/html/mso.go
+++ b/mjml/html/mso.go
@@ -460,5 +460,5 @@ func RenderMSOGroupTDClose(w io.StringWriter) error {
 
 // RenderMSOGroupTableClose renders MSO group table closing directly to Writer
 func RenderMSOGroupTableClose(w io.StringWriter) error {
-	return RenderMSOConditional(w, "</tr></table>")
+	return RenderMSOConditional(w, "</td></tr></table>")
 }

--- a/mjml/integration_test.go
+++ b/mjml/integration_test.go
@@ -112,6 +112,11 @@ func TestMJMLAgainstExpected(t *testing.T) {
 		{"mj-hero-vertical-align", "testdata/mj-hero-vertical-align.mjml"},
 		// MJ-SPACER test
 		{"mj-spacer", "testdata/mj-spacer.mjml"},
+		// MJ-TABLE tests
+		{"mj-table", "testdata/mj-table.mjml"},
+		{"mj-table-other", "testdata/mj-table-other.mjml"},
+		{"mj-table-table", "testdata/mj-table-table.mjml"},
+		{"mj-table-text", "testdata/mj-table-text.mjml"},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This PR adds support for the `mj-table` component to the MJML library, implementing email-safe table rendering with styling support. The implementation includes proper HTML table generation, border handling, and padding management.

- Adds complete `mj-table` component implementation with HTML table generation and MSO compatibility
- Refactors hardcoded strings to use constants for padding attributes across multiple components
- Fixes MSO group table closing tag to include missing `</td>` element