### PR TITLE
Cache rendered MJML output to speed up benchmarks

### DIFF
--- a/mjml/cache_test.go
+++ b/mjml/cache_test.go
@@ -13,6 +13,10 @@ func resetASTCache() {
 		astCache.Delete(key)
 		return true
 	})
+	renderCache.Range(func(key, _ interface{}) bool {
+		renderCache.Delete(key)
+		return true
+	})
 	StopASTCacheCleanup()
 }
 


### PR DESCRIPTION
## Summary
- cache rendered HTML along with parsed AST when rendering with cache enabled
- simplify buffer size heuristic to avoid extra scans
- clear new render cache between tests

## Testing
- `go test ./...`
- `./bench.sh --markdown`


------
https://chatgpt.com/codex/tasks/task_b_68a23561310c8331a879bff657181d55