### PR TITLE
Reduce MJML render overhead via preallocation

### DIFF
--- a/bench.sh
+++ b/bench.sh
@@ -49,7 +49,15 @@ BEGIN {
         printf "%-35s %8s %8s %10s\n", "Benchmark", "Time", "Memory", "Allocs"
         printf "%-35s %8s %8s %10s\n", "---------", "----", "------", "------"
     }
-}' | if [[ "$MARKDOWN" == "false" ]]; then column -t; else cat; fi
+}' | if [[ "$MARKDOWN" == "false" ]]; then
+    if command -v column >/dev/null 2>&1; then
+        column -t
+    else
+        cat
+    fi
+else
+    cat
+fi
 
 
 if [[ "$MARKDOWN" == "true" ]]; then

--- a/mjml/components/base.go
+++ b/mjml/components/base.go
@@ -1,9 +1,10 @@
 package components
 
 import (
-	"fmt"
-	"io"
-	"strings"
+        "fmt"
+        "io"
+        "strconv"
+        "strings"
 
 	"github.com/preslavrachev/gomjml/mjml/constants"
 	"github.com/preslavrachev/gomjml/mjml/debug"
@@ -61,7 +62,7 @@ type BaseComponent struct {
 
 // NewBaseComponent creates a new base component
 func NewBaseComponent(node *parser.MJMLNode, opts *options.RenderOpts) *BaseComponent {
-	attrs := make(map[string]string)
+    attrs := make(map[string]string, len(node.Attrs))
 	for _, attr := range node.Attrs {
 		attrs[attr.Name.Local] = attr.Value
 	}
@@ -71,9 +72,9 @@ func NewBaseComponent(node *parser.MJMLNode, opts *options.RenderOpts) *BaseComp
 	}
 
 	return &BaseComponent{
-		Node:           node,
-		Attrs:          attrs,
-		Children:       make([]Component, 0),
+                Node:           node,
+                Attrs:          attrs,
+                Children:       make([]Component, 0, len(node.Children)),
 		ContainerWidth: 0, // 0 means use default body width
 		Siblings:       1,
 		RawSiblings:    0,
@@ -284,8 +285,8 @@ func getPixelWidthString(widthPx int) string {
 	case 50:
 		return width50px
 	default:
-		// Fallback to fmt.Sprintf for uncommon widths
-		return fmt.Sprintf("%dpx", widthPx)
+            // Fallback using strconv for uncommon widths without fmt overhead
+            return strconv.Itoa(widthPx) + "px"
 	}
 }
 
@@ -381,7 +382,7 @@ func (bc *BaseComponent) ApplyDimensionStyles(tag *html.HTMLTag) *html.HTMLTag {
 func (bc *BaseComponent) AddDebugAttribute(tag *html.HTMLTag, componentType string) {
 	// Only add debug attributes if enabled in render options
 	if bc.RenderOpts != nil && bc.RenderOpts.DebugTags {
-		debugAttr := fmt.Sprintf("data-mj-debug-%s", componentType)
+            debugAttr := "data-mj-debug-" + componentType
 		tag.AddAttribute(debugAttr, "true")
 	}
 }
@@ -424,7 +425,7 @@ func (bc *BaseComponent) BuildClassAttribute(existingClasses ...string) string {
 // Returns empty string if no css-class is set, or " class=\"css-class-outlook\"" if set
 func (bc *BaseComponent) GetMSOClassAttribute() string {
 	if cssClass := bc.GetCSSClass(); cssClass != "" {
-		return fmt.Sprintf(` class="%s-outlook"`, cssClass)
+            return " class=\"" + cssClass + "-outlook\""
 	}
 	return ""
 }

--- a/mjml/components/column.go
+++ b/mjml/components/column.go
@@ -1,9 +1,9 @@
 package components
 
 import (
-	"fmt"
-	"io"
-	"strings"
+        "io"
+        "strconv"
+        "strings"
 
 	"github.com/preslavrachev/gomjml/mjml/constants"
 	"github.com/preslavrachev/gomjml/mjml/html"
@@ -162,8 +162,8 @@ func (c *MJColumnComponent) getAutoWidthPercent() string {
 	if nonRawSiblings <= 0 {
 		nonRawSiblings = 1
 	}
-	widthPercent := 100.0 / float64(nonRawSiblings)
-	return fmt.Sprintf("%.0f%%", widthPercent)
+        widthPercent := 100.0 / float64(nonRawSiblings)
+        return strconv.FormatFloat(widthPercent, 'f', 0, 64) + "%"
 }
 
 // GetParsedWidth returns the parsed width following MRML logic
@@ -188,17 +188,16 @@ func (c *MJColumnComponent) GetColumnClass() (string, styles.Size) {
 	parsedWidth := c.GetParsedWidth()
 	var className string
 
-	if parsedWidth.IsPercent() {
-		// Format: mj-column-per-{width} where dots are replaced with dashes
-		// Use float32 precision to match MRML's Rust f32 behavior
-		f32Value := float32(parsedWidth.Value())
-		widthStr := fmt.Sprintf("%g", f32Value)
-		className = fmt.Sprintf("mj-column-per-%s", strings.ReplaceAll(widthStr, ".", "-"))
-	} else {
-		// Format: mj-column-px-{width} for pixel values
-		widthStr := fmt.Sprintf("%.0f", parsedWidth.Value())
-		className = fmt.Sprintf("mj-column-px-%s", strings.ReplaceAll(widthStr, ".", "-"))
-	}
+        if parsedWidth.IsPercent() {
+                // Format: mj-column-per-{width} where dots are replaced with dashes
+                f32Value := float32(parsedWidth.Value())
+                widthStr := strconv.FormatFloat(float64(f32Value), 'f', -1, 32)
+                className = "mj-column-per-" + strings.ReplaceAll(widthStr, ".", "-")
+        } else {
+                // Format: mj-column-px-{width} for pixel values
+                widthStr := strconv.FormatFloat(parsedWidth.Value(), 'f', 0, 64)
+                className = "mj-column-px-" + strings.ReplaceAll(widthStr, ".", "-")
+        }
 
 	return className, parsedWidth
 }
@@ -213,8 +212,8 @@ func (c *MJColumnComponent) GetWidthAsPixel() string {
 	if containerWidth > 0 {
 		if parsedWidth.IsPercent() {
 			// Convert percentage to pixels
-			pixelValue := float64(containerWidth) * parsedWidth.Value() / 100.0
-			return fmt.Sprintf("%.0fpx", pixelValue)
+                        pixelValue := float64(containerWidth) * parsedWidth.Value() / 100.0
+                        return strconv.FormatFloat(pixelValue, 'f', 0, 64) + "px"
 		} else {
 			// Already in pixels
 			return parsedWidth.String()


### PR DESCRIPTION
## Summary
- avoid relying on `column` in benchmark script
- preallocate component attribute maps and children slices
- replace heavy `fmt` formatting with `strconv` in column width helpers

## Testing
- `go test ./...`
- `./bench.sh`


------
https://chatgpt.com/codex/tasks/task_b_68a338f5213c83318c699286eb440403